### PR TITLE
Correct the Request type consumed in api/src/authn.ts, remove redundant properties added to Express.Request

### DIFF
--- a/api/src/types/Express.d.ts
+++ b/api/src/types/Express.d.ts
@@ -1,20 +1,15 @@
-import type { IncomingHttpHeaders } from 'http';
-
 import type { UserDocument } from 'src/schema/core/User/UserModel.ts';
 
 // definition merging, this is the expected way to extend the Express types
 declare global {
   namespace Express {
+    // Don't consume Express.Request directly! The correct, complete, type is the `Request` type
+    // exported by `express-serve-static-core`, which itself Express.Request (including types added by
+    // the definition merging occuring here) but adds the request object properties and methods
     interface Request {
       locals?: {
         verification_url?: string;
       };
-
-      // TODO shouldn't these be picked up from definition merging? Something might be wrong
-      // with my typing approach
-      headers: IncomingHttpHeaders;
-      body?: any;
-      query?: any;
     }
     interface User {
       id?: string;


### PR DESCRIPTION
Promised follow up to hotfix d370e847d1df1f5c3b59651bef26cb9ea5df3b41, fixing an older outstanding typing mistake I'd made as well as the hacky portion of that hotfix.