### PR TITLE
feat: ignore docker updates for flux images

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -33,5 +33,16 @@
       matchPackageNames: ['ghcr.io/gimlet-io/capacitor-manifests'],
       pinDigests: false,
     },
+    {
+      description: 'Ignore docker updates for Flux images due to https://github.com/HC-IPPM/safe-inputs/pull/655#issuecomment-2377463287',
+      ignoreDeps: [
+        'ghcr.io/fluxcd/notification-controller',
+        'ghcr.io/fluxcd/image-reflector-controller',
+        'ghcr.io/fluxcd/image-automation-controller',
+        'ghcr.io/fluxcd/helm-controller',
+        'ghcr.io/fluxcd/kustomize-controller',
+        'ghcr.io/fluxcd/source-controller',
+      ],
+    },
   ],
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -36,20 +36,24 @@
     {
       matchFileNames: ['kubernetes/**/gotk-components.yaml'],
       matchDepNames: ['ghcr.io/fluxcd/**'],
+      digest: {
+        description: 'Allow and group image digest updating for Flux component images. See https://github.com/HC-IPPM/safe-inputs/pull/676',
+        groupName: 'Pin Flux Component Image Digests',
+      },
       pinDigest: {
-        description: 'Group image digest pinning updates for Flux component updates. See https://github.com/HC-IPPM/safe-inputs/pull/676',
+        description: 'Allow and group image digest pinning for Flux component images. See https://github.com/HC-IPPM/safe-inputs/pull/676',
         groupName: 'Pin Flux Component Image Digests',
       },
       major: {
-        description: 'Disable non-pin digest updates on Flux component images. See https://github.com/HC-IPPM/safe-inputs/pull/676',
+        description: 'Disable non-digest updates on Flux component images. See https://github.com/HC-IPPM/safe-inputs/pull/676',
         enabled: false,
       },
       patch: {
-        description: 'Disable non-pin digest updates on Flux component images. See https://github.com/HC-IPPM/safe-inputs/pull/676',
+        description: 'Disable non-digest updates on Flux component images. See https://github.com/HC-IPPM/safe-inputs/pull/676',
         enabled: false,
       },
       minor: {
-        description: 'Disable non-pin digest updates on Flux component images. See https://github.com/HC-IPPM/safe-inputs/pull/676',
+        description: 'Disable non-digest updates on Flux component images. See https://github.com/HC-IPPM/safe-inputs/pull/676',
         enabled: false,
       },
     },

--- a/renovate.json5
+++ b/renovate.json5
@@ -34,15 +34,24 @@
       pinDigests: false,
     },
     {
-      description: 'Ignore docker updates for Flux images due to https://github.com/HC-IPPM/safe-inputs/pull/655#issuecomment-2377463287',
-      ignoreDeps: [
-        'ghcr.io/fluxcd/notification-controller',
-        'ghcr.io/fluxcd/image-reflector-controller',
-        'ghcr.io/fluxcd/image-automation-controller',
-        'ghcr.io/fluxcd/helm-controller',
-        'ghcr.io/fluxcd/kustomize-controller',
-        'ghcr.io/fluxcd/source-controller',
-      ],
+      matchFileNames: ['kubernetes/**/gotk-components.yaml'],
+      matchDepNames: ['ghcr.io/fluxcd/**'],
+      pinDigest: {
+        description: 'Group image digest pinning updates for Flux component updates. See https://github.com/HC-IPPM/safe-inputs/pull/676',
+        groupName: 'Pin Flux Component Image Digests',
+      },
+      major: {
+        description: 'Disable non-pin digest updates on Flux component images. See https://github.com/HC-IPPM/safe-inputs/pull/676',
+        enabled: false,
+      },
+      patch: {
+        description: 'Disable non-pin digest updates on Flux component images. See https://github.com/HC-IPPM/safe-inputs/pull/676',
+        enabled: false,
+      },
+      minor: {
+        description: 'Disable non-pin digest updates on Flux component images. See https://github.com/HC-IPPM/safe-inputs/pull/676',
+        enabled: false,
+      },
     },
   ],
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -44,16 +44,16 @@
         description: 'Allow and group image digest pinning for Flux component images. See https://github.com/HC-IPPM/safe-inputs/pull/676',
         groupName: 'Pin Flux Component Image Digests',
       },
-      major: {
-        description: 'Disable non-digest updates on Flux component images. See https://github.com/HC-IPPM/safe-inputs/pull/676',
+      patch: {
+        description: 'Allow patch updates on Flux component images. See https://github.com/HC-IPPM/safe-inputs/pull/676',
         enabled: false,
       },
-      patch: {
-        description: 'Disable non-digest updates on Flux component images. See https://github.com/HC-IPPM/safe-inputs/pull/676',
+      major: {
+        description: 'Disable non-digest/patch updates on Flux component images. See https://github.com/HC-IPPM/safe-inputs/pull/676',
         enabled: false,
       },
       minor: {
-        description: 'Disable non-digest updates on Flux component images. See https://github.com/HC-IPPM/safe-inputs/pull/676',
+        description: 'Disable non-digest/patch updates on Flux component images. See https://github.com/HC-IPPM/safe-inputs/pull/676',
         enabled: false,
       },
     },

--- a/renovate.json5
+++ b/renovate.json5
@@ -34,7 +34,7 @@
       pinDigests: false,
     },
     {
-      matchFileNames: ['kubernetes/**/gotk-components.yaml'],
+      matchFileNames: ['kubernetes/**/flux-system/gotk-components.yaml'],
       matchDepNames: ['ghcr.io/fluxcd/**'],
       digest: {
         description: 'Allow and group image digest updating for Flux component images. See https://github.com/HC-IPPM/safe-inputs/pull/676',


### PR DESCRIPTION
Due to reason mentioned [here](https://github.com/HC-IPPM/safe-inputs/pull/655#issuecomment-2377463287).