### PR TITLE
fix: launch cloud function now that cloudbuild trigger is enabled

### DIFF
--- a/devsecops/artifact-registry-vulnerability-scanning/cli-deployment-reference/README.md
+++ b/devsecops/artifact-registry-vulnerability-scanning/cli-deployment-reference/README.md
@@ -56,7 +56,7 @@ gcloud artifacts docker images list --show-occurrences \
 northamerica-northeast1-docker.pkg.dev/phx-01jcqzx71nn/phx-01jcqzx71nn-repo-of-risk/nginx
 ```
 
-#### To get all vunerabilities for an image and save to file:
+#### To get all vunerabilities for an image and save to local file:
 
 ```
 gcloud artifacts docker images list --show-occurrences \


### PR DESCRIPTION
The devsecops/artifact-registry-vulnerability-scanning/cloudbuild deploys the vulnerability filtering cloud function.  Now that we have the trigger set up https://github.com/PHACDataHub/acm-core/pull/402, this PR is making a minor change to this directory in order to trigger the initial deployment of the function (with push to main).