### PR TITLE
fix: cloud function cloudbuild substitutions

### DIFF
--- a/devsecops/artifact-registry-vulnerability-scanning/cli-deployment-reference/README.md
+++ b/devsecops/artifact-registry-vulnerability-scanning/cli-deployment-reference/README.md
@@ -20,35 +20,6 @@ export REGION=northamerica-northeast1
 ./init.sh
 ```
 
-## Or instead deploy with Cloud Build
-
-Comment out the deployment / push image protion in init.sh (below the dashed line), then deploy:
-
-```
-gcloud builds submit --config ./devsecops/artifact-registry-vulnerability-scanning/cloudbuild.yaml --substitutions=_BRANCH_NAME=$BRANCH_NAME,_BUCKET_NAME=$BUCKET_NAME,_VULN_CLOUD_FUNCTION_SERVICE_ACCOUNT=$VULN_CLOUD_FUNCTION_SERVICE_ACCOUNT,_PROJECT_ID=$PROJECT_ID
-
-```
-
-### Push a test image with vunerabilities to Artifact Registry to see bucket output
-
-If Artifact Registry repository does not yet exists:
-
-```
-gcloud artifacts repositories create $REPO_NAME \
- --location=northamerica-northeast1 \
- --repository-format=docker  \
- --project=$PROJECT_ID
-```
-
-Then pull and push image:
-
-```
-gcloud auth configure-docker northamerica-northeast1-docker.pkg.dev
-docker pull nginx
-docker tag nginx northamerica-northeast1-docker.pkg.dev/$PROJECT_ID/$REPO_NAME/nginx
-docker push northamerica-northeast1-docker.pkg.dev/$PROJECT_ID/$REPO_NAME/nginx
-```
-
 #### To get list of severities of an image (not used in function):
 
 ```

--- a/devsecops/artifact-registry-vulnerability-scanning/cli-deployment-reference/init.sh
+++ b/devsecops/artifact-registry-vulnerability-scanning/cli-deployment-reference/init.sh
@@ -87,10 +87,6 @@ gsutil iam ch serviceAccount:$VULN_CLOUD_FUNCTION_SERVICE_ACCOUNT@$PROJECT_ID.ia
 # # As using acm-core, this wasn't needed)
 # gcloud pubsub topics create container-analysis-occurrences-v1 --project=$PROJECT_ID
 
-# ------------------------------------------------------------------------------------------------------------------------------
-# Comment out below if using Cloud Build to deploy function / gcloud push image (see README)
-# ------------------------------------------------------------------------------------------------------------------------------
-
 # ---- DEPLOY CLOUD FUNCTION ---- (this will be done with cloud build in the future)
 #   Node (https://cloud.google.com/sdk/gcloud/reference/functions/deploy)
 # changed to cloud run (https://cloud.google.com/blog/products/serverless/google-cloud-functions-is-now-cloud-run-functions)
@@ -119,9 +115,6 @@ gcloud auth configure-docker northamerica-northeast1-docker.pkg.dev
 docker pull nginx
 docker tag nginx northamerica-northeast1-docker.pkg.dev/$PROJECT_ID/$REPO_NAME/nginx
 docker push northamerica-northeast1-docker.pkg.dev/$PROJECT_ID/$REPO_NAME/nginx
-
-
-
 
 
 

--- a/devsecops/artifact-registry-vulnerability-scanning/cloudbuild.yaml
+++ b/devsecops/artifact-registry-vulnerability-scanning/cloudbuild.yaml
@@ -6,7 +6,7 @@ steps:
     args:
       - '-c'
       - |
-        if [[ "$_BRANCH_NAME" == "main" ]]
+        if [[ "$BRANCH_NAME" == "main" ]]
         then
           gcloud functions deploy imageVulnPubSubHandler \
             --gen2 \
@@ -16,10 +16,14 @@ steps:
             --entry-point=imageVulnPubSubHandler \
             --set-env-vars=BUCKET_NAME=$_BUCKET_NAME \
             --region=northamerica-northeast1 \
-            --service-account $_VULN_CLOUD_FUNCTION_SERVICE_ACCOUNT@$_PROJECT_ID.iam.gserviceaccount.com
+            --service-account $_VULN_CLOUD_FUNCTION_SERVICE_ACCOUNT@$PROJECT_ID.iam.gserviceaccount.com
         else
           exit 0
         fi
+
+substitutions:
+  _BUCKET_NAME: safe-inputs-devsecops-outputs-for-dashboard
+  _VULN_CLOUD_FUNCTION_SERVICE_ACCOUNT: phx-01j1tbke0ax-vuln-gcf
 
 options:
   defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET


### PR DESCRIPTION
When triggering the cloudbuild for the cloud function locally, I found I needed to supply substitutions for variables (had done this with the cli command), and unless they were prefixed by '_' it would produce an error.   Unfortunately, when using the cloudbuild trigger, _BRANCH_NAME isn't a built in substitution so the function never deployed when it had actually merged with main as $BRANCH_NAME == 'main', not $_BRANCH_NAME == 'main' as it was written in the function. 

When fixing this, I also noticed I wasn't providing the bucket name or service account substitutions for this when using the cloud build trigger. 

In this PR, the instructions to deploy function with cloudbuild locally were removed, and in cloudbuild.yaml, added the missing substitutions and changed the built in ones to not have the underscore. 