### PR TITLE
fix: trigger cloud function deployment - added custom build service account tag in cloud build. 

### DIFF
--- a/devsecops/artifact-registry-vulnerability-scanning/cli-deployment-reference/init.sh
+++ b/devsecops/artifact-registry-vulnerability-scanning/cli-deployment-reference/init.sh
@@ -95,7 +95,7 @@ gcloud functions deploy imageVulnPubSubHandler \
     --region=northamerica-northeast1 \
     --service-account $VULN_CLOUD_FUNCTION_SERVICE_ACCOUNT@$PROJECT_ID.iam.gserviceaccount.com
 
-# ---- TEST ---- by pushing image with vunerabilities
+# ---- TEST ---- by pushing an image with vunerabilities
 # Create Artifact Registry Repo to store image (we don't need to do this as there's one already in Safe inputs)
 gcloud artifacts repositories create $REPO_NAME \
  --location=northamerica-northeast1 \

--- a/devsecops/artifact-registry-vulnerability-scanning/cloudbuild.yaml
+++ b/devsecops/artifact-registry-vulnerability-scanning/cloudbuild.yaml
@@ -16,6 +16,7 @@ steps:
             --entry-point=imageVulnPubSubHandler \
             --set-env-vars=BUCKET_NAME=$_BUCKET_NAME \
             --region=northamerica-northeast1 \
+            --build-service-account=projects/$PROJECT_ID/serviceAccounts/$_CLOUDBUILD_SERVICE_ACCOUNT \
             --service-account $_VULN_CLOUD_FUNCTION_SERVICE_ACCOUNT@$PROJECT_ID.iam.gserviceaccount.com
         else
           exit 0
@@ -24,6 +25,7 @@ steps:
 substitutions:
   _BUCKET_NAME: safe-inputs-devsecops-outputs-for-dashboard
   _VULN_CLOUD_FUNCTION_SERVICE_ACCOUNT: phx-01j1tbke0ax-vuln-gcf
+  _CLOUDBUILD_SERVICE_ACCOUNT: phx-01j1tbke0ax-cloudbuild@phx-01j1tbke0ax.iam.gserviceaccount.com
 
 options:
   defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET


### PR DESCRIPTION
Added the --build-service-account line to cloudbuild.yaml to use the custom cloudbuild service account (that has the service account user on the cloud function). (suggestion from https://github.com/PHACDataHub/acm-core/pull/414, https://cloud.google.com/functions/docs/reference/iam/roles#additional-configuration) . Also made a minor change to init.sh (added the word 'an' to a comment with the intention of triggering cloudbuild deployment of the function, but now we have an actual change to do that.)