### PR TITLE
fix: wrapped project_id in brackets in cloudbuild

### DIFF
--- a/devsecops/artifact-registry-vulnerability-scanning/cloudbuild.yaml
+++ b/devsecops/artifact-registry-vulnerability-scanning/cloudbuild.yaml
@@ -16,8 +16,8 @@ steps:
             --entry-point=imageVulnPubSubHandler \
             --set-env-vars=BUCKET_NAME=${_BUCKET_NAME} \
             --region=northamerica-northeast1 \
-            --build-service-account=projects/${_PROJECT_ID}/serviceAccounts/${_CLOUDBUILD_SERVICE_ACCOUNT} \
-            --service-account ${_VULN_CLOUD_FUNCTION_SERVICE_ACCOUNT}@${_PROJECT_ID}.iam.gserviceaccount.com
+            --build-service-account=projects/${PROJECT_ID}/serviceAccounts/${_CLOUDBUILD_SERVICE_ACCOUNT} \
+            --service-account ${_VULN_CLOUD_FUNCTION_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com
         else
           exit 0
         fi
@@ -26,7 +26,6 @@ substitutions:
   _BUCKET_NAME: safe-inputs-devsecops-outputs-for-dashboard
   _VULN_CLOUD_FUNCTION_SERVICE_ACCOUNT: phx-01j1tbke0ax-vuln-gcf
   _CLOUDBUILD_SERVICE_ACCOUNT: phx-01j1tbke0ax-cloudbuild@phx-01j1tbke0ax.iam.gserviceaccount.com
-  _PROJECT_ID: phx-01j1tbke0ax
 
 options:
   defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET

--- a/devsecops/artifact-registry-vulnerability-scanning/cloudbuild.yaml
+++ b/devsecops/artifact-registry-vulnerability-scanning/cloudbuild.yaml
@@ -17,7 +17,7 @@ steps:
             --set-env-vars=BUCKET_NAME=${_BUCKET_NAME} \
             --region=northamerica-northeast1 \
             --build-service-account=projects/${PROJECT_ID}/serviceAccounts/${_CLOUDBUILD_SERVICE_ACCOUNT} \
-            --service-account ${_VULN_CLOUD_FUNCTION_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com
+            --service-account=${_VULN_CLOUD_FUNCTION_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com
         else
           exit 0
         fi

--- a/devsecops/artifact-registry-vulnerability-scanning/cloudbuild.yaml
+++ b/devsecops/artifact-registry-vulnerability-scanning/cloudbuild.yaml
@@ -6,7 +6,7 @@ steps:
     args:
       - '-c'
       - |
-        if [[ "$BRANCH_NAME" == "main" ]]
+        if [[ "${BRANCH_NAME}" == "main" ]]
         then
           gcloud functions deploy imageVulnPubSubHandler \
             --gen2 \
@@ -14,10 +14,10 @@ steps:
             --runtime=nodejs18 \
             --trigger-topic=container-analysis-occurrences-v1 \
             --entry-point=imageVulnPubSubHandler \
-            --set-env-vars=BUCKET_NAME=$_BUCKET_NAME \
+            --set-env-vars=BUCKET_NAME=${_BUCKET_NAME} \
             --region=northamerica-northeast1 \
-            --build-service-account=projects/$PROJECT_ID/serviceAccounts/$_CLOUDBUILD_SERVICE_ACCOUNT \
-            --service-account $_VULN_CLOUD_FUNCTION_SERVICE_ACCOUNT@$PROJECT_ID.iam.gserviceaccount.com
+            --build-service-account=projects/${_PROJECT_ID}/serviceAccounts/${_CLOUDBUILD_SERVICE_ACCOUNT} \
+            --service-account ${_VULN_CLOUD_FUNCTION_SERVICE_ACCOUNT}@${_PROJECT_ID}.iam.gserviceaccount.com
         else
           exit 0
         fi
@@ -26,6 +26,7 @@ substitutions:
   _BUCKET_NAME: safe-inputs-devsecops-outputs-for-dashboard
   _VULN_CLOUD_FUNCTION_SERVICE_ACCOUNT: phx-01j1tbke0ax-vuln-gcf
   _CLOUDBUILD_SERVICE_ACCOUNT: phx-01j1tbke0ax-cloudbuild@phx-01j1tbke0ax.iam.gserviceaccount.com
+  _PROJECT_ID: phx-01j1tbke0ax
 
 options:
   defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET


### PR DESCRIPTION
The last PR (https://github.com/HC-IPPM/safe-inputs/pull/1033) failed (https://console.cloud.google.com/cloud-build/builds;region=northamerica-northeast1/bacfca1c-40f3-4230-a271-91d0817863fc?project=phx-01j1tbke0ax).  

I double checked the the permissions, and the cloudbuild service account looks like it has the act as on the cloud function service account.  The error message looks like the PROJECT_ID built in cloudbuild substitution wasn't working correctly as it's just a dash in the error message.  

Added in brackets around the cloudbuild variables to see if this will resolve error and pick up PROJECT_ID (next will try hard coding). 

(Also added an '=' in the --service-account line to be consistent)