### PR TITLE
feat: initial test coverage reporting (saving to bucket)

### DIFF
--- a/api/cloudbuild.yaml
+++ b/api/cloudbuild.yaml
@@ -19,9 +19,17 @@ steps:
       set -o pipefail
       set -o nounset
 
+      # Create the coverage directory 
+      mkdir -p /workspace/coverage
+      chmod -R 777 /workspace/coverage
+
       # disable TTY output for the compose environment, the ansi characters printed when a TTY is attached
       # are just junk characters to the GCP cloudbuild logs
       DOCKER_NETWORK=cloudbuild DOCKER_TTY=false docker compose -f api/docker-compose.dev-test.yaml up --exit-code-from api-test
+
+      # List the coverage directory contents to confirm files exist
+      echo "Listing files in /workspace/coverage:"
+      ls -la /workspace/coverage
 
   - id: 'Upload test coverage report to bucket'
     name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:latest'
@@ -43,11 +51,11 @@ steps:
         # If this isn't the first commit on this branch, then determine test coverage trend 
         if [ "$last_commit_on_this_branch" ]; then
             
-          # Download the last coverage report in order to be able to use jq
+          # Download the last coverage report in order to be able to use jq to search
           gsutil cp "$last_commit_on_this_branch" last_commit_coverage.json
 
           # Extract current and last coverage percentages
-          this_coverage=$(jq -r '.total.statements.pct' coverage/coverage-summary.json)
+          this_coverage=$(jq -r '.total.statements.pct' /workspace/coverage/coverage-summary.json)
           last_coverage=$(jq -r '.total.statements.pct' last_commit_coverage.json)
 
           # Compare coverage
@@ -56,9 +64,9 @@ steps:
           coverage_difference=$(echo "$this_coverage - $last_coverage" | bc)
           echo "Coverage difference: $coverage_difference%"
 
-          echo "Updating report with the coverage difference..."
-          jq ". + {\"difference_from_last_commit\": {\"statements_pct\": $coverage_difference}}" coverage/coverage-summary.json > coverage/updated-coverage-summary.json
-          mv coverage/updated-coverage-summary.json coverage/coverage-summary.json
+          echo "Apending report with the coverage difference..."
+          jq ". + {\"difference_from_last_commit\": {\"statements_pct\": $coverage_difference}}" /workspace/coverage/coverage-summary.json > /workspace/coverage/updated-coverage-summary.json
+          mv /workspace/coverage/updated-coverage-summary.json  /workspace/coverage/coverage-summary.json
 
         else
           echo "No previous coverage reports found on this branch."
@@ -66,10 +74,10 @@ steps:
         fi
 
         echo "formating file..."
-        jq '.' coverage/coverage-summary.json > coverage/coverage-pretty.json
+        jq '.' /workspace/coverage/coverage-summary.json > /workspace/coverage/coverage-pretty.json
 
         echo "Copying coverage report to GCS bucket..."
-        gsutil -m cp -r ./coverage/coverage-pretty.json gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/api/${BRANCH_NAME}__${timestamp}__${SHORT_SHA}.json
+        gsutil -m cp -r /workspace/coverage/coverage-pretty.json gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/api/${BRANCH_NAME}__${timestamp}__${SHORT_SHA}.json
 
   - id: generate-image-name
     name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'

--- a/api/cloudbuild.yaml
+++ b/api/cloudbuild.yaml
@@ -34,53 +34,54 @@ steps:
   - id: 'Upload test coverage report to bucket'
     name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:latest'
     dir: api
-    name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'
-    script: |
-      #!/usr/bin/env bash
-      set -o errexit
-      set -o pipefail
-      set -o nounset
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        set -o errexit
+        set -o pipefail
+        set -o nounset
+        
+        # Install jq and bc
+        apt-get update && apt-get install -y jq bc
 
-      # Install jq and bc
-      apt-get update && apt-get install -y jq bc
+        # Generate a timestamp
+        export timestamp=$(date +%s)
 
-      # Generate a timestamp
-      export timestamp=$(date +%s)
+        # Get the last commit's coverage report from GCS
+        echo "Getting last commit's test coverage report..."
+        last_commit_on_this_branch=$(gsutil ls gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/api/ | grep "$BRANCH_NAME" | sort | tail -n 1)
 
-      # Get the last commit's coverage report from GCS
-      echo "Getting last commit's test coverage report..."
-      last_commit_on_this_branch=$(gsutil ls gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/api/ | grep "$BRANCH_NAME" | sort | tail -n 1)
+        # If this isn't the first commit on this branch, then determine test coverage trend 
+        if [ "$last_commit_on_this_branch" ]; then
+            
+          # Download the last coverage report in order to be able to use jq to search
+          gsutil cp "$last_commit_on_this_branch" last_commit_coverage.json
 
-      # If this isn't the first commit on this branch, then determine test coverage trend 
-      if [ "$last_commit_on_this_branch" ]; then
-          
-        # Download the last coverage report in order to be able to use jq to search
-        gsutil cp "$last_commit_on_this_branch" last_commit_coverage.json
+          # Extract current and last coverage percentages
+          this_coverage=$(jq -r '.total.statements.pct' /workspace/coverage/coverage-summary.json)
+          last_coverage=$(jq -r '.total.statements.pct' last_commit_coverage.json)
 
-        # Extract current and last coverage percentages
-        this_coverage=$(jq -r '.total.statements.pct' /workspace/coverage/coverage-summary.json)
-        last_coverage=$(jq -r '.total.statements.pct' last_commit_coverage.json)
+          # Compare coverage
+          echo "Current coverage: $this_coverage%"
+          echo "Last coverage: $last_coverage%"
+          coverage_difference=$(echo "$this_coverage - $last_coverage" | bc)
+          echo "Coverage difference: $coverage_difference%"
 
-        # Compare coverage
-        echo "Current coverage: $this_coverage%"
-        echo "Last coverage: $last_coverage%"
-        coverage_difference=$(echo "$this_coverage - $last_coverage" | bc)
-        echo "Coverage difference: $coverage_difference%"
+          echo "Apending report with the coverage difference..."
+          jq ". + {\"difference_from_last_commit\": {\"statements_pct\": $coverage_difference}}" /workspace/coverage/coverage-summary.json > /workspace/coverage/updated-coverage-summary.json
+          mv /workspace/coverage/updated-coverage-summary.json  /workspace/coverage/coverage-summary.json
 
-        echo "Apending report with the coverage difference..."
-        jq ". + {\"difference_from_last_commit\": {\"statements_pct\": $coverage_difference}}" /workspace/coverage/coverage-summary.json > /workspace/coverage/updated-coverage-summary.json
-        mv /workspace/coverage/updated-coverage-summary.json  /workspace/coverage/coverage-summary.json
+        else
+          echo "No previous coverage reports found on this branch."
+          echo "Skipping coverage trend calculations."
+        fi
 
-      else
-        echo "No previous coverage reports found on this branch."
-        echo "Skipping coverage trend calculations."
-      fi
+        echo "formating file..."
+        jq '.' /workspace/coverage/coverage-summary.json > /workspace/coverage/coverage-pretty.json
 
-      echo "formating file..."
-      jq '.' /workspace/coverage/coverage-summary.json > /workspace/coverage/coverage-pretty.json
-
-      echo "Copying coverage report to GCS bucket..."
-      gsutil -m cp -r /workspace/coverage/coverage-pretty.json gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/api/${BRANCH_NAME}__${timestamp}__${SHORT_SHA}.json
+        echo "Copying coverage report to GCS bucket..."
+        gsutil -m cp -r /workspace/coverage/coverage-pretty.json gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/api/${BRANCH_NAME}__${timestamp}__${SHORT_SHA}.json
 
   - id: generate-image-name
     name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'

--- a/api/cloudbuild.yaml
+++ b/api/cloudbuild.yaml
@@ -41,7 +41,7 @@ steps:
         set -o errexit
         set -o pipefail
         set -o nounset
-        
+
         # Install jq and bc
         apt-get update && apt-get install -y jq bc
 

--- a/api/cloudbuild.yaml
+++ b/api/cloudbuild.yaml
@@ -23,6 +23,54 @@ steps:
       # are just junk characters to the GCP cloudbuild logs
       DOCKER_NETWORK=cloudbuild DOCKER_TTY=false docker compose -f api/docker-compose.dev-test.yaml up --exit-code-from api-test
 
+  - id: 'Upload test coverage report to bucket'
+    name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:latest'
+    dir: api
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        # Install jq and bc
+        apt-get update && apt-get install -y jq bc
+
+        # Generate a timestamp
+        export timestamp=$(date +%s)
+
+        # Get the last commit's coverage report from GCS
+        echo "Getting last commit's test coverage report..."
+        last_commit_on_this_branch=$(gsutil ls gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/api/ | grep "$BRANCH_NAME" | sort | tail -n 1)
+
+        # If this isn't the first commit on this branch, then determine test coverage trend 
+        if [ "$last_commit_on_this_branch" ]; then
+            
+          # Download the last coverage report in order to be able to use jq
+          gsutil cp "$last_commit_on_this_branch" last_commit_coverage.json
+
+          # Extract current and last coverage percentages
+          this_coverage=$(jq -r '.total.statements.pct' coverage/coverage-summary.json)
+          last_coverage=$(jq -r '.total.statements.pct' last_commit_coverage.json)
+
+          # Compare coverage
+          echo "Current coverage: $this_coverage%"
+          echo "Last coverage: $last_coverage%"
+          coverage_difference=$(echo "$this_coverage - $last_coverage" | bc)
+          echo "Coverage difference: $coverage_difference%"
+
+          echo "Updating report with the coverage difference..."
+          jq ". + {\"difference_from_last_commit\": {\"statements_pct\": $coverage_difference}}" coverage/coverage-summary.json > coverage/updated-coverage-summary.json
+          mv coverage/updated-coverage-summary.json coverage/coverage-summary.json
+
+        else
+          echo "No previous coverage reports found on this branch."
+          echo "Skipping coverage trend calculations."
+        fi
+
+        echo "formating file..."
+        jq '.' coverage/coverage-summary.json > coverage/coverage-pretty.json
+
+        echo "Copying coverage report to GCS bucket..."
+        gsutil -m cp -r ./coverage/coverage-pretty.json gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/api/${BRANCH_NAME}__${timestamp}__${SHORT_SHA}.json
+
   - id: generate-image-name
     name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'
     entrypoint: 'bash'

--- a/api/cloudbuild.yaml
+++ b/api/cloudbuild.yaml
@@ -34,50 +34,53 @@ steps:
   - id: 'Upload test coverage report to bucket'
     name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:latest'
     dir: api
-    entrypoint: bash
-    args:
-      - '-c'
-      - |
-        # Install jq and bc
-        apt-get update && apt-get install -y jq bc
+    name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'
+    script: |
+      #!/usr/bin/env bash
+      set -o errexit
+      set -o pipefail
+      set -o nounset
 
-        # Generate a timestamp
-        export timestamp=$(date +%s)
+      # Install jq and bc
+      apt-get update && apt-get install -y jq bc
 
-        # Get the last commit's coverage report from GCS
-        echo "Getting last commit's test coverage report..."
-        last_commit_on_this_branch=$(gsutil ls gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/api/ | grep "$BRANCH_NAME" | sort | tail -n 1)
+      # Generate a timestamp
+      export timestamp=$(date +%s)
 
-        # If this isn't the first commit on this branch, then determine test coverage trend 
-        if [ "$last_commit_on_this_branch" ]; then
-            
-          # Download the last coverage report in order to be able to use jq to search
-          gsutil cp "$last_commit_on_this_branch" last_commit_coverage.json
+      # Get the last commit's coverage report from GCS
+      echo "Getting last commit's test coverage report..."
+      last_commit_on_this_branch=$(gsutil ls gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/api/ | grep "$BRANCH_NAME" | sort | tail -n 1)
 
-          # Extract current and last coverage percentages
-          this_coverage=$(jq -r '.total.statements.pct' /workspace/coverage/coverage-summary.json)
-          last_coverage=$(jq -r '.total.statements.pct' last_commit_coverage.json)
+      # If this isn't the first commit on this branch, then determine test coverage trend 
+      if [ "$last_commit_on_this_branch" ]; then
+          
+        # Download the last coverage report in order to be able to use jq to search
+        gsutil cp "$last_commit_on_this_branch" last_commit_coverage.json
 
-          # Compare coverage
-          echo "Current coverage: $this_coverage%"
-          echo "Last coverage: $last_coverage%"
-          coverage_difference=$(echo "$this_coverage - $last_coverage" | bc)
-          echo "Coverage difference: $coverage_difference%"
+        # Extract current and last coverage percentages
+        this_coverage=$(jq -r '.total.statements.pct' /workspace/coverage/coverage-summary.json)
+        last_coverage=$(jq -r '.total.statements.pct' last_commit_coverage.json)
 
-          echo "Apending report with the coverage difference..."
-          jq ". + {\"difference_from_last_commit\": {\"statements_pct\": $coverage_difference}}" /workspace/coverage/coverage-summary.json > /workspace/coverage/updated-coverage-summary.json
-          mv /workspace/coverage/updated-coverage-summary.json  /workspace/coverage/coverage-summary.json
+        # Compare coverage
+        echo "Current coverage: $this_coverage%"
+        echo "Last coverage: $last_coverage%"
+        coverage_difference=$(echo "$this_coverage - $last_coverage" | bc)
+        echo "Coverage difference: $coverage_difference%"
 
-        else
-          echo "No previous coverage reports found on this branch."
-          echo "Skipping coverage trend calculations."
-        fi
+        echo "Apending report with the coverage difference..."
+        jq ". + {\"difference_from_last_commit\": {\"statements_pct\": $coverage_difference}}" /workspace/coverage/coverage-summary.json > /workspace/coverage/updated-coverage-summary.json
+        mv /workspace/coverage/updated-coverage-summary.json  /workspace/coverage/coverage-summary.json
 
-        echo "formating file..."
-        jq '.' /workspace/coverage/coverage-summary.json > /workspace/coverage/coverage-pretty.json
+      else
+        echo "No previous coverage reports found on this branch."
+        echo "Skipping coverage trend calculations."
+      fi
 
-        echo "Copying coverage report to GCS bucket..."
-        gsutil -m cp -r /workspace/coverage/coverage-pretty.json gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/api/${BRANCH_NAME}__${timestamp}__${SHORT_SHA}.json
+      echo "formating file..."
+      jq '.' /workspace/coverage/coverage-summary.json > /workspace/coverage/coverage-pretty.json
+
+      echo "Copying coverage report to GCS bucket..."
+      gsutil -m cp -r /workspace/coverage/coverage-pretty.json gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/api/${BRANCH_NAME}__${timestamp}__${SHORT_SHA}.json
 
   - id: generate-image-name
     name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'

--- a/api/docker-compose.dev-test.yaml
+++ b/api/docker-compose.dev-test.yaml
@@ -55,6 +55,7 @@ services:
     volumes:
       - .:/home/node-dev/project
       - ./.env.dev-public:/home/node-dev/project/.env
+      - /workspace/coverage:/home/node-dev/project/coverage
     entrypoint:
       - ../node-dev-entrypoint.once.sh
     command: npm run jest:${DOCKER_API_COMMAND:-docker}

--- a/api/package.json
+++ b/api/package.json
@@ -21,7 +21,7 @@
     "dev:docker-debug": "nodemon --exec tsx --inspect='0.0.0.0:9229' ./src/index.ts",
     "pretest": "npm run test:down",
     "test": "docker compose -f ./docker-compose.dev-test.yaml up --exit-code-from api-test",
-    "jest:docker": "jest --coverage --coverageReporters text",
+    "jest:docker": "jest --coverage --coverageReporters=text --coverageReporters=json-summary --coverageDirectory ./coverage",
     "pretest:watch": "npm run test:down",
     "test:watch": "DOCKER_API_COMMAND=docker-watch docker compose -f ./docker-compose.dev-test.yaml up",
     "jest:docker-watch": "jest --coverage --coverageReporters text --watchAll",

--- a/devsecops/axe-testing/Dockerfile
+++ b/devsecops/axe-testing/Dockerfile
@@ -21,9 +21,6 @@ RUN apk update && apk add --no-cache \
 COPY package*.json ./
 RUN npm ci
 
-# Create and set permissions for the coverage directory
-RUN mkdir -p /app/coverage && chmod -R 777 /app/coverage
-
 # Copy the rest of the source code for building (and testing)
 COPY ./axeignore.json .
 COPY ./src ./src
@@ -43,6 +40,9 @@ EXPOSE 8080
 
 # Create a non-root user
 RUN addgroup -g 1001 -S puppeteer && adduser -u 1001 -S puppeteer -G puppeteer
+
+# Create and set permissions for the coverage directory
+RUN mkdir -p /app/coverage && chmod -R 777 /app/coverage && chown -R puppeteer:puppeteer /app/coverage
 
 # Set ownership of the working directory to puppeteer user
 RUN chown -R puppeteer:puppeteer /app

--- a/devsecops/axe-testing/Dockerfile
+++ b/devsecops/axe-testing/Dockerfile
@@ -21,6 +21,9 @@ RUN apk update && apk add --no-cache \
 COPY package*.json ./
 RUN npm ci
 
+# Create and set permissions for the coverage directory
+RUN mkdir -p /app/coverage && chmod -R 777 /app/coverage
+
 # Copy the rest of the source code for building (and testing)
 COPY ./axeignore.json .
 COPY ./src ./src

--- a/devsecops/axe-testing/cloudbuild.yaml
+++ b/devsecops/axe-testing/cloudbuild.yaml
@@ -6,29 +6,13 @@ steps:
     args:
       - '-c'
       - |
-        # Create the coverage directory on the host
+        # Create the coverage directory 
         mkdir -p /workspace/coverage
         chmod -R 777 /workspace/coverage
 
-        # mkdir -p ./coverage
-        # chmod -R 777 ./coverage
-        # docker run --rm --network host -v ./coverage:/app/coverage axe-e2e npm run test:all
-
-        # Build the Docker image
+        # Run tests in the Docker container with volume mounting for coverage report 
         docker build -t axe-e2e .
-
-        # Run tests in the Docker container with volume mounting
         docker run --rm --network host -v /workspace/coverage:/app/coverage axe-e2e npm run test:all
-
-        # List the coverage directory to confirm files exist
-        echo "Listing files in /workspace/coverage:"
-        ls -la /workspace/coverage
-
-        # Check for the presence of the coverage report
-        if [ ! -f /workspace/coverage/coverage-summary.json ]; then
-          echo "Error: coverage-summary.json not found in /workspace/coverage"
-          exit 1
-        fi
 
   - id: 'Upload test coverage report to bucket'
     name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:latest'
@@ -37,12 +21,6 @@ steps:
     args:
       - '-c'
       - |
-
-        echo "files found"
-        ls -la /workspace/coverage
-
-        echo $pwd
-
         # Install jq and bc
         apt-get update && apt-get install -y jq bc
 

--- a/devsecops/axe-testing/cloudbuild.yaml
+++ b/devsecops/axe-testing/cloudbuild.yaml
@@ -11,7 +11,7 @@ steps:
 
   - id: 'Upload test coverage report to bucket'
     name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:latest'
-    dir: ui
+    dir: 'devsecops/axe-testing'
     entrypoint: bash
     args:
       - '-c'

--- a/devsecops/axe-testing/cloudbuild.yaml
+++ b/devsecops/axe-testing/cloudbuild.yaml
@@ -7,7 +7,7 @@ steps:
       - '-c'
       - |
         docker build -t axe-e2e . && \
-        docker run --rm --network host -v ${PWD}/coverage:/app/coverage axe-e2e npm run test:all
+        docker run --rm --network host -v /workspace/coverage:/app/coverage axe-e2e npm run test:all
 
   - id: 'Upload test coverage report to bucket'
     name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:latest'

--- a/devsecops/axe-testing/cloudbuild.yaml
+++ b/devsecops/axe-testing/cloudbuild.yaml
@@ -7,7 +7,7 @@ steps:
       - '-c'
       - |
         docker build -t axe-e2e . && \
-        docker run --rm --network host -v /workspace/coverage:/app/coverage axe-e2e npm run test:all
+        docker run --rm --network host -v ./coverage:/app/coverage axe-e2e npm run test:all
 
   - id: 'Upload test coverage report to bucket'
     name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:latest'
@@ -21,6 +21,9 @@ steps:
 
         # Generate a timestamp
         export timestamp=$(date +%s)
+
+        echo ls
+        echo ls ./coverage
 
         # Get the last commit's coverage report from GCS
         echo "Getting last commit's test coverage report..."

--- a/devsecops/axe-testing/cloudbuild.yaml
+++ b/devsecops/axe-testing/cloudbuild.yaml
@@ -6,10 +6,29 @@ steps:
     args:
       - '-c'
       - |
-        mkdir -p /workspace/coverage && \
-        docker build -t axe-e2e . && \
+        # Create the coverage directory on the host
+        mkdir -p /workspace/coverage
+        chmod -R 777 /workspace/coverage
+
+        # mkdir -p ./coverage
+        # chmod -R 777 ./coverage
+        # docker run --rm --network host -v ./coverage:/app/coverage axe-e2e npm run test:all
+
+        # Build the Docker image
+        docker build -t axe-e2e .
+
+        # Run tests in the Docker container with volume mounting
         docker run --rm --network host -v /workspace/coverage:/app/coverage axe-e2e npm run test:all
-        ls /workspace/coverage
+
+        # List the coverage directory to confirm files exist
+        echo "Listing files in /workspace/coverage:"
+        ls -la /workspace/coverage
+
+        # Check for the presence of the coverage report
+        if [ ! -f /workspace/coverage/coverage-summary.json ]; then
+          echo "Error: coverage-summary.json not found in /workspace/coverage"
+          exit 1
+        fi
 
   - id: 'Upload test coverage report to bucket'
     name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:latest'
@@ -18,6 +37,12 @@ steps:
     args:
       - '-c'
       - |
+
+        echo "files found"
+        ls -la /workspace/coverage
+
+        echo $pwd
+
         # Install jq and bc
         apt-get update && apt-get install -y jq bc
 
@@ -35,7 +60,7 @@ steps:
           gsutil cp "$last_commit_on_this_branch" last_commit_coverage.json
 
           # Extract current and last coverage percentages
-          this_coverage=$(jq -r '.total.statements.pct' coverage/coverage-summary.json)
+          this_coverage=$(jq -r '.total.statements.pct' /workspace/coverage/coverage-summary.json)
           last_coverage=$(jq -r '.total.statements.pct' last_commit_coverage.json)
 
           # Compare coverage
@@ -44,9 +69,9 @@ steps:
           coverage_difference=$(echo "$this_coverage - $last_coverage" | bc)
           echo "Coverage difference: $coverage_difference%"
 
-          echo "Updating report with the coverage difference..."
-          jq ". + {\"difference_from_last_commit\": {\"statements_pct\": $coverage_difference}}" coverage/coverage-summary.json > coverage/updated-coverage-summary.json
-          mv coverage/updated-coverage-summary.json coverage/coverage-summary.json
+          echo "Apending report with the coverage difference..."
+          jq ". + {\"difference_from_last_commit\": {\"statements_pct\": $coverage_difference}}" /workspace/coverage/coverage-summary.json > /workspace/coverage/updated-coverage-summary.json
+          mv /workspace/coverage/updated-coverage-summary.json  /workspace/coverage/coverage-summary.json
 
         else
           echo "No previous coverage reports found on this branch."
@@ -54,9 +79,9 @@ steps:
         fi
 
         echo "formating file..."
-        jq '.' coverage/coverage-summary.json > coverage/coverage-pretty.json
+        jq '.' /workspace/coverage/coverage-summary.json > /workspace/coverage/coverage-pretty.json
 
         echo "Copying coverage report to GCS bucket..."
-        gsutil -m cp -r ./coverage/coverage-pretty.json gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/a11y/${BRANCH_NAME}__${timestamp}__${SHORT_SHA}.json
+        gsutil -m cp -r /workspace/coverage/coverage-pretty.json gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/a11y/${BRANCH_NAME}__${timestamp}__${SHORT_SHA}.json
 options:
   defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET

--- a/devsecops/axe-testing/cloudbuild.yaml
+++ b/devsecops/axe-testing/cloudbuild.yaml
@@ -6,8 +6,10 @@ steps:
     args:
       - '-c'
       - |
+        mkdir -p /workspace/coverage && \
         docker build -t axe-e2e . && \
-        docker run --rm --network host -v ./coverage:/app/coverage axe-e2e npm run test:all
+        docker run --rm --network host -v /workspace/coverage:/app/coverage axe-e2e npm run test:all
+        ls /workspace/coverage
 
   - id: 'Upload test coverage report to bucket'
     name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:latest'
@@ -21,9 +23,6 @@ steps:
 
         # Generate a timestamp
         export timestamp=$(date +%s)
-
-        echo ls
-        echo ls ./coverage
 
         # Get the last commit's coverage report from GCS
         echo "Getting last commit's test coverage report..."

--- a/devsecops/axe-testing/cloudbuild.yaml
+++ b/devsecops/axe-testing/cloudbuild.yaml
@@ -17,53 +17,55 @@ steps:
       docker run --rm --network host -v /workspace/coverage:/app/coverage axe-e2e npm run test:all
 
   - id: 'Upload test coverage report to bucket'
+    name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:latest'
     dir: 'devsecops/axe-testing'
-    name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'
-    script: |
-      #!/usr/bin/env bash
-      set -o errexit
-      set -o pipefail
-      set -o nounset
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        set -o errexit
+        set -o pipefail
+        set -o nounset
 
-      # Install jq and bc
-      apt-get update && apt-get install -y jq bc
+        # Install jq and bc
+        apt-get update && apt-get install -y jq bc
 
-      # Generate a timestamp
-      export timestamp=$(date +%s)
+        # Generate a timestamp
+        export timestamp=$(date +%s)
 
-      # Get the last commit's coverage report from GCS
-      echo "Getting last commit's test coverage report..."
-      last_commit_on_this_branch=$(gsutil ls gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/a11y/ | grep "$BRANCH_NAME" | sort | tail -n 1)
+        # Get the last commit's coverage report from GCS
+        echo "Getting last commit's test coverage report..."
+        last_commit_on_this_branch=$(gsutil ls gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/a11y/ | grep "$BRANCH_NAME" | sort | tail -n 1)
 
-      # If this isn't the first commit on this branch, then determine test coverage trend 
-      if [ "$last_commit_on_this_branch" ]; then
-          
-        # Download the last coverage report in order to be able to use jq
-        gsutil cp "$last_commit_on_this_branch" last_commit_coverage.json
+        # If this isn't the first commit on this branch, then determine test coverage trend 
+        if [ "$last_commit_on_this_branch" ]; then
+            
+          # Download the last coverage report in order to be able to use jq
+          gsutil cp "$last_commit_on_this_branch" last_commit_coverage.json
 
-        # Extract current and last coverage percentages
-        this_coverage=$(jq -r '.total.statements.pct' /workspace/coverage/coverage-summary.json)
-        last_coverage=$(jq -r '.total.statements.pct' last_commit_coverage.json)
+          # Extract current and last coverage percentages
+          this_coverage=$(jq -r '.total.statements.pct' /workspace/coverage/coverage-summary.json)
+          last_coverage=$(jq -r '.total.statements.pct' last_commit_coverage.json)
 
-        # Compare coverage
-        echo "Current coverage: $this_coverage%"
-        echo "Last coverage: $last_coverage%"
-        coverage_difference=$(echo "$this_coverage - $last_coverage" | bc)
-        echo "Coverage difference: $coverage_difference%"
+          # Compare coverage
+          echo "Current coverage: $this_coverage%"
+          echo "Last coverage: $last_coverage%"
+          coverage_difference=$(echo "$this_coverage - $last_coverage" | bc)
+          echo "Coverage difference: $coverage_difference%"
 
-        echo "Apending report with the coverage difference..."
-        jq ". + {\"difference_from_last_commit\": {\"statements_pct\": $coverage_difference}}" /workspace/coverage/coverage-summary.json > /workspace/coverage/updated-coverage-summary.json
-        mv /workspace/coverage/updated-coverage-summary.json  /workspace/coverage/coverage-summary.json
+          echo "Apending report with the coverage difference..."
+          jq ". + {\"difference_from_last_commit\": {\"statements_pct\": $coverage_difference}}" /workspace/coverage/coverage-summary.json > /workspace/coverage/updated-coverage-summary.json
+          mv /workspace/coverage/updated-coverage-summary.json  /workspace/coverage/coverage-summary.json
 
-      else
-        echo "No previous coverage reports found on this branch."
-        echo "Skipping coverage trend calculations."
-      fi
+        else
+          echo "No previous coverage reports found on this branch."
+          echo "Skipping coverage trend calculations."
+        fi
 
-      echo "formating file..."
-      jq '.' /workspace/coverage/coverage-summary.json > /workspace/coverage/coverage-pretty.json
+        echo "formating file..."
+        jq '.' /workspace/coverage/coverage-summary.json > /workspace/coverage/coverage-pretty.json
 
-      echo "Copying coverage report to GCS bucket..."
-      gsutil -m cp -r /workspace/coverage/coverage-pretty.json gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/a11y/${BRANCH_NAME}__${timestamp}__${SHORT_SHA}.json
+        echo "Copying coverage report to GCS bucket..."
+        gsutil -m cp -r /workspace/coverage/coverage-pretty.json gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/a11y/${BRANCH_NAME}__${timestamp}__${SHORT_SHA}.json
 options:
   defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET

--- a/devsecops/axe-testing/cloudbuild.yaml
+++ b/devsecops/axe-testing/cloudbuild.yaml
@@ -7,6 +7,54 @@ steps:
       - '-c'
       - |
         docker build -t axe-e2e . && \
-        docker run --rm --network host axe-e2e npm run test:all
+        docker run --rm --network host -v ${PWD}/coverage:/app/coverage axe-e2e npm run test:all
+
+  - id: 'Upload test coverage report to bucket'
+    name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:latest'
+    dir: ui
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        # Install jq and bc
+        apt-get update && apt-get install -y jq bc
+
+        # Generate a timestamp
+        export timestamp=$(date +%s)
+
+        # Get the last commit's coverage report from GCS
+        echo "Getting last commit's test coverage report..."
+        last_commit_on_this_branch=$(gsutil ls gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/a11y/ | grep "$BRANCH_NAME" | sort | tail -n 1)
+
+        # If this isn't the first commit on this branch, then determine test coverage trend 
+        if [ "$last_commit_on_this_branch" ]; then
+            
+          # Download the last coverage report in order to be able to use jq
+          gsutil cp "$last_commit_on_this_branch" last_commit_coverage.json
+
+          # Extract current and last coverage percentages
+          this_coverage=$(jq -r '.total.statements.pct' coverage/coverage-summary.json)
+          last_coverage=$(jq -r '.total.statements.pct' last_commit_coverage.json)
+
+          # Compare coverage
+          echo "Current coverage: $this_coverage%"
+          echo "Last coverage: $last_coverage%"
+          coverage_difference=$(echo "$this_coverage - $last_coverage" | bc)
+          echo "Coverage difference: $coverage_difference%"
+
+          echo "Updating report with the coverage difference..."
+          jq ". + {\"difference_from_last_commit\": {\"statements_pct\": $coverage_difference}}" coverage/coverage-summary.json > coverage/updated-coverage-summary.json
+          mv coverage/updated-coverage-summary.json coverage/coverage-summary.json
+
+        else
+          echo "No previous coverage reports found on this branch."
+          echo "Skipping coverage trend calculations."
+        fi
+
+        echo "formating file..."
+        jq '.' coverage/coverage-summary.json > coverage/coverage-pretty.json
+
+        echo "Copying coverage report to GCS bucket..."
+        gsutil -m cp -r ./coverage/coverage-pretty.json gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/a11y/${BRANCH_NAME}__${timestamp}__${SHORT_SHA}.json
 options:
   defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET

--- a/devsecops/axe-testing/cloudbuild.yaml
+++ b/devsecops/axe-testing/cloudbuild.yaml
@@ -1,65 +1,69 @@
 steps:
   - id: 'Run tests for a11y scanning'
-    name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'
     dir: 'devsecops/axe-testing'
-    entrypoint: 'bash'
-    args:
-      - '-c'
-      - |
-        # Create the coverage directory 
-        mkdir -p /workspace/coverage
-        chmod -R 777 /workspace/coverage
+    name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'
+    script: |
+      #!/usr/bin/env bash
+      set -o errexit
+      set -o pipefail
+      set -o nounset
 
-        # Run tests in the Docker container with volume mounting for coverage report 
-        docker build -t axe-e2e .
-        docker run --rm --network host -v /workspace/coverage:/app/coverage axe-e2e npm run test:all
+      # Create the coverage directory 
+      mkdir -p /workspace/coverage
+      chmod -R 777 /workspace/coverage
+
+      # Run tests in the Docker container with volume mounting for coverage report 
+      docker build -t axe-e2e .
+      docker run --rm --network host -v /workspace/coverage:/app/coverage axe-e2e npm run test:all
 
   - id: 'Upload test coverage report to bucket'
-    name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:latest'
     dir: 'devsecops/axe-testing'
-    entrypoint: bash
-    args:
-      - '-c'
-      - |
-        # Install jq and bc
-        apt-get update && apt-get install -y jq bc
+    name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'
+    script: |
+      #!/usr/bin/env bash
+      set -o errexit
+      set -o pipefail
+      set -o nounset
 
-        # Generate a timestamp
-        export timestamp=$(date +%s)
+      # Install jq and bc
+      apt-get update && apt-get install -y jq bc
 
-        # Get the last commit's coverage report from GCS
-        echo "Getting last commit's test coverage report..."
-        last_commit_on_this_branch=$(gsutil ls gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/a11y/ | grep "$BRANCH_NAME" | sort | tail -n 1)
+      # Generate a timestamp
+      export timestamp=$(date +%s)
 
-        # If this isn't the first commit on this branch, then determine test coverage trend 
-        if [ "$last_commit_on_this_branch" ]; then
-            
-          # Download the last coverage report in order to be able to use jq
-          gsutil cp "$last_commit_on_this_branch" last_commit_coverage.json
+      # Get the last commit's coverage report from GCS
+      echo "Getting last commit's test coverage report..."
+      last_commit_on_this_branch=$(gsutil ls gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/a11y/ | grep "$BRANCH_NAME" | sort | tail -n 1)
 
-          # Extract current and last coverage percentages
-          this_coverage=$(jq -r '.total.statements.pct' /workspace/coverage/coverage-summary.json)
-          last_coverage=$(jq -r '.total.statements.pct' last_commit_coverage.json)
+      # If this isn't the first commit on this branch, then determine test coverage trend 
+      if [ "$last_commit_on_this_branch" ]; then
+          
+        # Download the last coverage report in order to be able to use jq
+        gsutil cp "$last_commit_on_this_branch" last_commit_coverage.json
 
-          # Compare coverage
-          echo "Current coverage: $this_coverage%"
-          echo "Last coverage: $last_coverage%"
-          coverage_difference=$(echo "$this_coverage - $last_coverage" | bc)
-          echo "Coverage difference: $coverage_difference%"
+        # Extract current and last coverage percentages
+        this_coverage=$(jq -r '.total.statements.pct' /workspace/coverage/coverage-summary.json)
+        last_coverage=$(jq -r '.total.statements.pct' last_commit_coverage.json)
 
-          echo "Apending report with the coverage difference..."
-          jq ". + {\"difference_from_last_commit\": {\"statements_pct\": $coverage_difference}}" /workspace/coverage/coverage-summary.json > /workspace/coverage/updated-coverage-summary.json
-          mv /workspace/coverage/updated-coverage-summary.json  /workspace/coverage/coverage-summary.json
+        # Compare coverage
+        echo "Current coverage: $this_coverage%"
+        echo "Last coverage: $last_coverage%"
+        coverage_difference=$(echo "$this_coverage - $last_coverage" | bc)
+        echo "Coverage difference: $coverage_difference%"
 
-        else
-          echo "No previous coverage reports found on this branch."
-          echo "Skipping coverage trend calculations."
-        fi
+        echo "Apending report with the coverage difference..."
+        jq ". + {\"difference_from_last_commit\": {\"statements_pct\": $coverage_difference}}" /workspace/coverage/coverage-summary.json > /workspace/coverage/updated-coverage-summary.json
+        mv /workspace/coverage/updated-coverage-summary.json  /workspace/coverage/coverage-summary.json
 
-        echo "formating file..."
-        jq '.' /workspace/coverage/coverage-summary.json > /workspace/coverage/coverage-pretty.json
+      else
+        echo "No previous coverage reports found on this branch."
+        echo "Skipping coverage trend calculations."
+      fi
 
-        echo "Copying coverage report to GCS bucket..."
-        gsutil -m cp -r /workspace/coverage/coverage-pretty.json gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/a11y/${BRANCH_NAME}__${timestamp}__${SHORT_SHA}.json
+      echo "formating file..."
+      jq '.' /workspace/coverage/coverage-summary.json > /workspace/coverage/coverage-pretty.json
+
+      echo "Copying coverage report to GCS bucket..."
+      gsutil -m cp -r /workspace/coverage/coverage-pretty.json gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/a11y/${BRANCH_NAME}__${timestamp}__${SHORT_SHA}.json
 options:
   defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET

--- a/devsecops/axe-testing/package.json
+++ b/devsecops/axe-testing/package.json
@@ -10,7 +10,7 @@
     "start": "node --experimental-vm-modules index.js",
     "prestart:docker": "mkdir -p axe-results && sudo chmod 777 axe-results && docker build -t axe .",
     "start:docker": "docker run --rm --network host -v ${PWD}/axe-results:/app/axe-results -e COMMIT_SHA=$(git rev-parse HEAD) axe",
-    "test:unit": "NODE_OPTIONS=--experimental-vm-modules npx jest --config=jest.unit.config.cjs --coverage",
+    "test:unit": "NODE_OPTIONS=--experimental-vm-modules npx jest --config=jest.unit.config.cjs --coverage --coverageReporters=text --coverageReporters=json-summary --coverageDirectory=./coverage",
     "pretest:e2e": "npx http-server ./e2e-tests/test-pages -p 8080 & echo $! > server.pid && for i in {1..10}; do nc -z localhost 8080 && break || echo 'Waiting for server to be ready...'; sleep 1; done",
     "test:e2e": "NODE_OPTIONS=--experimental-vm-modules npx jest --config=jest.e2e.config.cjs",
     "posttest:e2e": "kill $(cat server.pid) || true",

--- a/ui/cloudbuild.yaml
+++ b/ui/cloudbuild.yaml
@@ -17,6 +17,15 @@ steps:
     entrypoint: npm
     args: ['test']
 
+  - id: 'Upload test coverage'
+    name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:latest'
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        echo "Copying coverage report to GCP bucket..."
+        gsutil -m cp -r ./ui/coverage/* gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/ui/
+
   - id: 'Axe a11y testing setup'
     name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'
     dir: ./

--- a/ui/cloudbuild.yaml
+++ b/ui/cloudbuild.yaml
@@ -18,9 +18,8 @@ steps:
     args:
       - '-c'
       - |
-  
         echo "Make globally writable coverge dir, to be mounted as a volume on the test container"
-        mkdir --mode 777 ./coverage
+        mkdir --mode 777 ./ui/coverage
         npm test
 
   - id: 'Upload test coverage'

--- a/ui/cloudbuild.yaml
+++ b/ui/cloudbuild.yaml
@@ -30,9 +30,12 @@ steps:
         # Generate a timestamp
         export timestamp=$(date +%s)
 
+        echo $BRANCH_NAME
+        echo $SHORT_SHA
+
         # Get the last commit's coverage report from GCS
         echo "Getting last commit's test coverage report..."
-        last_commit_on_this_branch=$(gsutil ls gs://test-outputs-go-here/test-coverage/ui/ | grep "$bRANCH_NAME" | sort | tail -n 1)
+        last_commit_on_this_branch=$(gsutil ls gs://test-outputs-go-here/test-coverage/ui/ | grep "$BRANCH_NAME" | sort | tail -n 1)
 
         # If this isn't the first commit on this branch, then determine test coverage trend 
         if [ "$last_commit_on_this_branch" ]; then
@@ -64,6 +67,8 @@ steps:
 
         echo "Copying coverage report to GCS bucket..."
         gsutil -m cp -r ./coverage/coverage-pretty.json gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/ui/${BRANCH_NAME}__${timestamp}__${SHORT_SHA}.json
+
+        echo ${BRANCH_NAME}__${timestamp}__${SHORT_SHA}.json
 
   - id: 'Axe a11y testing setup'
     name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'

--- a/ui/cloudbuild.yaml
+++ b/ui/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
 
         # Get the last commit's coverage report from GCS
         echo "Getting last commit's test coverage report..."
-        last_commit_on_this_branch=$(gsutil ls gs://test-outputs-go-here/test-coverage/ui/ | grep "$BRANCH_NAME" | sort | tail -n 1)
+        last_commit_on_this_branch=$(gsutil ls gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/ui/ | grep "$BRANCH_NAME" | sort | tail -n 1)
 
         # If this isn't the first commit on this branch, then determine test coverage trend 
         if [ "$last_commit_on_this_branch" ]; then

--- a/ui/cloudbuild.yaml
+++ b/ui/cloudbuild.yaml
@@ -27,7 +27,7 @@ steps:
         set -o errexit
         set -o pipefail
         set -o nounset
-        
+
         # Install jq and bc
         apt-get update && apt-get install -y jq bc
 

--- a/ui/cloudbuild.yaml
+++ b/ui/cloudbuild.yaml
@@ -5,11 +5,11 @@ steps:
     entrypoint: npm
     args: ['ci', '--no-optional']
 
-  # - id: 'Check types'
-  #   name: 'node:lts-alpine3.19@sha256:40dc4b415c17b85bea9be05314b4a753f45a4e1716bb31c01182e6c53d51a654'
-  #   dir: ui
-  #   entrypoint: npm
-  #   args: ['run', 'typecheck']
+  - id: 'Check types'
+    name: 'node:lts-alpine3.19@sha256:40dc4b415c17b85bea9be05314b4a753f45a4e1716bb31c01182e6c53d51a654'
+    dir: ui
+    entrypoint: npm
+    args: ['run', 'typecheck']
 
   - id: Test
     name: 'node:lts-alpine3.19@sha256:40dc4b415c17b85bea9be05314b4a753f45a4e1716bb31c01182e6c53d51a654'
@@ -17,117 +17,149 @@ steps:
     entrypoint: npm
     args: ['test']
 
-  - id: 'Upload test coverage to bucket'
+  - id: 'Upload test coverage report to bucket'
     name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:latest'
     dir: ui
     entrypoint: bash
     args:
       - '-c'
       - |
-        # Install jq and bc 
+        # Install jq and bc
         apt-get update && apt-get install -y jq bc
 
+        # Generate a timestamp
+        export timestamp=$(date +%s)
+
+        # Get the last commit's coverage report from GCS
+        echo "Getting last commit's test coverage report..."
+        last_commit_on_this_branch=$(gsutil ls gs://test-outputs-go-here/test-coverage/ui/ | grep "$bRANCH_NAME" | sort | tail -n 1)
+
+        # If this isn't the first commit on this branch, then determine test coverage trend 
+        if [ "$last_commit_on_this_branch" ]; then
+            
+          # Download the last coverage report in order to be able to use jq
+          gsutil cp "$last_commit_on_this_branch" last_commit_coverage.json
+
+          # Extract current and last coverage percentages
+          this_coverage=$(jq -r '.total.statements.pct' coverage/coverage-summary.json)
+          last_coverage=$(jq -r '.total.statements.pct' last_commit_coverage.json)
+
+          # Compare coverage
+          echo "Current coverage: $this_coverage%"
+          echo "Last coverage: $last_coverage%"
+          coverage_difference=$(echo "$this_coverage - $last_coverage" | bc)
+          echo "Coverage difference: $coverage_difference%"
+
+          echo "Updating report with the coverage difference..."
+          jq ". + {\"difference_from_last_commit\": {\"statements_pct\": $coverage_difference}}" coverage/coverage-summary.json > coverage/updated-coverage-summary.json
+          mv coverage/updated-coverage-summary.json coverage/coverage-summary.json
+
+        else
+          echo "No previous coverage reports found on this branch."
+          echo "Skipping coverage trend calculations."
+        fi
+
         echo "formating file..."
-        jq '.' coverage/coverage-final.json > coverage/coverage-pretty.json
+        jq '.' coverage/coverage-summary.json > coverage/coverage-pretty.json
 
-        echo "Copying coverage report to GCP bucket..."
-        gsutil -m cp -r ./coverage/coverage-pretty.json gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/ui/${BRANCH_NAME}-${timestamp}-${SHORT_SHA}.json
+        echo "Copying coverage report to GCS bucket..."
+        gsutil -m cp -r ./coverage/coverage-pretty.json gs://test-outputs-go-here/test-coverage/ui/${BRANCH_NAME}__${timestamp}__${SHORT_SHA}.json
 
-  # - id: 'Axe a11y testing setup'
-  #   name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'
-  #   dir: ./
-  #   script: |
-  #     #!/bin/bash
-  #     set -o errexit
-  #     set -o pipefail
-  #     set -o nounset
+  - id: 'Axe a11y testing setup'
+    name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'
+    dir: ./
+    script: |
+      #!/bin/bash
+      set -o errexit
+      set -o pipefail
+      set -o nounset
 
-  #     # docker compose dev environment, detached mode, with ui-gql-codegen disabled because it a) doesn't need to run here, and
-  #     # b) has permissions issues when running in this context
-  #     docker compose -f ./docker-compose.dev.yaml up -d --scale ui-gql-codegen=0
+      # docker compose dev environment, detached mode, with ui-gql-codegen disabled because it a) doesn't need to run here, and
+      # b) has permissions issues when running in this context
+      docker compose -f ./docker-compose.dev.yaml up -d --scale ui-gql-codegen=0
 
-  #     docker build -t axe ./devsecops/axe-testing
+      docker build -t axe ./devsecops/axe-testing
 
-  #     # fix for a permission issues when running the axe tests, need to be able to write to ./axe-results/*.json
-  #     mkdir -p /workspace/axe-results
-  #     chmod -R 777 /workspace/axe-results
+      # fix for a permission issues when running the axe tests, need to be able to write to ./axe-results/*.json
+      mkdir -p /workspace/axe-results
+      chmod -R 777 /workspace/axe-results
 
-  #     # make sure the ui server is ready before continuing
-  #     docker run \
-  #       --volume "${PWD}":/home/project \
-  #       --workdir /home/project \
-  #       --network host \
-  #       --entrypoint node \
-  #       node:lts-alpine3.19@sha256:2d8c24d9104bda27e07dced6d7110aa728dd917dde8255d8af3678e532b339d6 \
-  #       ./wait_for_service.cjs http://localhost:8080/signin
+      # make sure the ui server is ready before continuing
+      docker run \
+        --volume "${PWD}":/home/project \
+        --workdir /home/project \
+        --network host \
+        --entrypoint node \
+        node:lts-alpine3.19@sha256:2d8c24d9104bda27e07dced6d7110aa728dd917dde8255d8af3678e532b339d6 \
+        ./wait_for_service.cjs http://localhost:8080/signin
 
-  # - id: 'Axe a11y testing'
-  #   name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'
-  #   args: [
-  #       'run',
-  #       '--network',
-  #       'host', # to access the dev environment
-  #       '--rm',
-  #       '--volume',
-  #       '/workspace/axe-results:/app/axe-results',
-  #       '--env',
-  #       '${COMMIT_SHA}',
-  #       'axe',
-  #     ]
+  - id: 'Axe a11y testing'
+    name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'
+    args: [
+        'run',
+        '--network',
+        'host', # to access the dev environment
+        '--rm',
+        '--volume',
+        '/workspace/axe-results:/app/axe-results',
+        '--env',
+        '${COMMIT_SHA}',
+        'axe',
+      ]
 
-  # - id: upload-axe-results-gcs
-  #   name: 'gcr.io/cloud-builders/gsutil@sha256:3cb717eb2b8e1e8140868a08d31af752f7ec99949f78023743df2fc6bd41512e'
-  #   entrypoint: 'bash'
-  #   args:
-  #     - '-c'
-  #     - |
-  #       gsutil cp /workspace/axe-results/ci_axe_results_*.json \
-  #       gs://safe-inputs-devsecops-outputs-for-dashboard/axe-ci-results/$BRANCH_NAME-$COMMIT_SHA.json
+  - id: upload-axe-results-gcs
+    name: 'gcr.io/cloud-builders/gsutil@sha256:3cb717eb2b8e1e8140868a08d31af752f7ec99949f78023743df2fc6bd41512e'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        gsutil cp /workspace/axe-results/ci_axe_results_*.json \
+        gs://safe-inputs-devsecops-outputs-for-dashboard/axe-ci-results/$BRANCH_NAME-$COMMIT_SHA.json
 
-  # - id: docker-compose-down-dev-environment
-  #   name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'
-  #   entrypoint: 'bash'
-  #   args:
-  #     - '-c'
-  #     - |
-  #       docker compose -f ./docker-compose.dev.yaml down -v
+  - id: docker-compose-down-dev-environment
+    name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        docker compose -f ./docker-compose.dev.yaml down -v
 
-  # - id: generate-image-name
-  #   name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'
-  #   entrypoint: 'bash'
-  #   dir: ui
-  #   args:
-  #     - '-c'
-  #     - |
-  #       echo "northamerica-northeast1-docker.pkg.dev/${PROJECT_ID}/phx-01j1tbke0ax-safeinputs/ui:$BRANCH_NAME-$COMMIT_SHA-$(date +%s)" > /workspace/imagename
+  - id: generate-image-name
+    name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'
+    entrypoint: 'bash'
+    dir: ui
+    args:
+      - '-c'
+      - |
+        echo "northamerica-northeast1-docker.pkg.dev/${PROJECT_ID}/phx-01j1tbke0ax-safeinputs/ui:$BRANCH_NAME-$COMMIT_SHA-$(date +%s)" > /workspace/imagename
 
-  # - id: build-if-main
-  #   name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'
-  #   entrypoint: 'bash'
-  #   dir: ui
-  #   args:
-  #     - '-c'
-  #     - |
-  #       if [[ "$BRANCH_NAME" == "main" ]]
-  #       then
-  #         image=$(cat /workspace/imagename)
-  #         docker build -t $image -f ./Dockerfile.prod .
-  #       else
-  #         exit 0
-  #       fi
+  - id: build-if-main
+    name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'
+    entrypoint: 'bash'
+    dir: ui
+    args:
+      - '-c'
+      - |
+        if [[ "$BRANCH_NAME" == "main" ]]
+        then
+          image=$(cat /workspace/imagename)
+          docker build -t $image -f ./Dockerfile.prod .
+        else
+          exit 0
+        fi
 
-  # - id: push-if-main
-  #   name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'
-  #   entrypoint: 'bash'
-  #   args:
-  #     - '-c'
-  #     - |
-  #       if [[ "$BRANCH_NAME" == "main" ]]
-  #       then
-  #         image=$(cat /workspace/imagename)
-  #         docker push $image
-  #       else
-  #         exit 0
-  #       fi
+  - id: push-if-main
+    name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        if [[ "$BRANCH_NAME" == "main" ]]
+        then
+          image=$(cat /workspace/imagename)
+          docker push $image
+        else
+          exit 0
+        fi
 options:
   defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET

--- a/ui/cloudbuild.yaml
+++ b/ui/cloudbuild.yaml
@@ -18,7 +18,9 @@ steps:
     args:
       - '-c'
       - |
-        mkdir -p ./coverage
+  
+        echo "Make globally writable coverge dir, to be mounted as a volume on the test container"
+        mkdir --mode 777 ./coverage
         npm test
 
   - id: 'Upload test coverage'

--- a/ui/cloudbuild.yaml
+++ b/ui/cloudbuild.yaml
@@ -18,11 +18,10 @@ steps:
     args:
       - '-c'
       - |
-        echo "Make globally writable coverge dir, to be mounted as a volume on the test container"
-        mkdir -p ./coverage
         npm test
-        echo "Listing coverage directory contents:"
-        ls -la ./coverage
+
+      #   echo "Make globally writable coverge dir, to be mounted as a volume on the test container"
+      # mkdir -p ./coverage
 
   - id: 'Upload test coverage'
     name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:latest'
@@ -32,7 +31,10 @@ steps:
       - '-c'
       - |
         echo "Copying coverage report to GCP bucket..."
-        gsutil -m cp -r ./coverage/* gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/ui/
+        gsutil -m cp -r ./coverage/coverage-final.json gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/ui/${BRANCH_NAME}-${SHORT_SHA}.json
+
+      #   echo "formating file..."
+      # # jq '.' coverage/coverage-final.json > coverage/coverage-pretty.json
 
   - id: 'Axe a11y testing setup'
     name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'

--- a/ui/cloudbuild.yaml
+++ b/ui/cloudbuild.yaml
@@ -24,6 +24,10 @@ steps:
     args:
       - '-c'
       - |
+        set -o errexit
+        set -o pipefail
+        set -o nounset
+        
         # Install jq and bc
         apt-get update && apt-get install -y jq bc
 

--- a/ui/cloudbuild.yaml
+++ b/ui/cloudbuild.yaml
@@ -5,11 +5,11 @@ steps:
     entrypoint: npm
     args: ['ci', '--no-optional']
 
-  - id: 'Check types'
-    name: 'node:lts-alpine3.19@sha256:40dc4b415c17b85bea9be05314b4a753f45a4e1716bb31c01182e6c53d51a654'
-    dir: ui
-    entrypoint: npm
-    args: ['run', 'typecheck']
+  # - id: 'Check types'
+  #   name: 'node:lts-alpine3.19@sha256:40dc4b415c17b85bea9be05314b4a753f45a4e1716bb31c01182e6c53d51a654'
+  #   dir: ui
+  #   entrypoint: npm
+  #   args: ['run', 'typecheck']
 
   - id: Test
     name: 'node:lts-alpine3.19@sha256:40dc4b415c17b85bea9be05314b4a753f45a4e1716bb31c01182e6c53d51a654'

--- a/ui/cloudbuild.yaml
+++ b/ui/cloudbuild.yaml
@@ -14,123 +14,120 @@ steps:
   - id: Test
     name: 'node:lts-alpine3.19@sha256:40dc4b415c17b85bea9be05314b4a753f45a4e1716bb31c01182e6c53d51a654'
     dir: ui
-    entrypoint: sh
-    args:
-      - '-c'
-      - |
-        npm test
+    entrypoint: npm
+    args: ['test']
 
-      #   echo "Make globally writable coverge dir, to be mounted as a volume on the test container"
-      # mkdir -p ./coverage
-
-  - id: 'Upload test coverage'
+  - id: 'Upload test coverage to bucket'
     name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:latest'
     dir: ui
     entrypoint: bash
     args:
       - '-c'
       - |
+        # Install jq and bc 
+        apt-get update && apt-get install -y jq bc
+
+        echo "formating file..."
+        jq '.' coverage/coverage-final.json > coverage/coverage-pretty.json
+
         echo "Copying coverage report to GCP bucket..."
-        gsutil -m cp -r ./coverage/coverage-final.json gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/ui/${BRANCH_NAME}-${SHORT_SHA}.json
+        gsutil -m cp -r ./coverage/coverage-pretty.json gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/ui/${BRANCH_NAME}-${timestamp}-${SHORT_SHA}.json
 
-      #   echo "formating file..."
-      # # jq '.' coverage/coverage-final.json > coverage/coverage-pretty.json
+  # - id: 'Axe a11y testing setup'
+  #   name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'
+  #   dir: ./
+  #   script: |
+  #     #!/bin/bash
+  #     set -o errexit
+  #     set -o pipefail
+  #     set -o nounset
 
-  - id: 'Axe a11y testing setup'
-    name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'
-    dir: ./
-    script: |
-      #!/bin/bash
-      set -o errexit
-      set -o pipefail
-      set -o nounset
+  #     # docker compose dev environment, detached mode, with ui-gql-codegen disabled because it a) doesn't need to run here, and
+  #     # b) has permissions issues when running in this context
+  #     docker compose -f ./docker-compose.dev.yaml up -d --scale ui-gql-codegen=0
 
-      # docker compose dev environment, detached mode, with ui-gql-codegen disabled because it a) doesn't need to run here, and
-      # b) has permissions issues when running in this context
-      docker compose -f ./docker-compose.dev.yaml up -d --scale ui-gql-codegen=0
+  #     docker build -t axe ./devsecops/axe-testing
 
-      docker build -t axe ./devsecops/axe-testing
+  #     # fix for a permission issues when running the axe tests, need to be able to write to ./axe-results/*.json
+  #     mkdir -p /workspace/axe-results
+  #     chmod -R 777 /workspace/axe-results
 
-      # fix for a permission issues when running the axe tests, need to be able to write to ./axe-results/*.json
-      mkdir -p /workspace/axe-results
-      chmod -R 777 /workspace/axe-results
+  #     # make sure the ui server is ready before continuing
+  #     docker run \
+  #       --volume "${PWD}":/home/project \
+  #       --workdir /home/project \
+  #       --network host \
+  #       --entrypoint node \
+  #       node:lts-alpine3.19@sha256:2d8c24d9104bda27e07dced6d7110aa728dd917dde8255d8af3678e532b339d6 \
+  #       ./wait_for_service.cjs http://localhost:8080/signin
 
-      # make sure the ui server is ready before continuing
-      docker run \
-        --volume "${PWD}":/home/project \
-        --workdir /home/project \
-        --network host \
-        --entrypoint node \
-        node:lts-alpine3.19@sha256:2d8c24d9104bda27e07dced6d7110aa728dd917dde8255d8af3678e532b339d6 \
-        ./wait_for_service.cjs http://localhost:8080/signin
+  # - id: 'Axe a11y testing'
+  #   name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'
+  #   args: [
+  #       'run',
+  #       '--network',
+  #       'host', # to access the dev environment
+  #       '--rm',
+  #       '--volume',
+  #       '/workspace/axe-results:/app/axe-results',
+  #       '--env',
+  #       '${COMMIT_SHA}',
+  #       'axe',
+  #     ]
 
-  - id: 'Axe a11y testing'
-    name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'
-    args: [
-        'run',
-        '--network',
-        'host', # to access the dev environment
-        '--rm',
-        '--volume',
-        '/workspace/axe-results:/app/axe-results',
-        '--env',
-        '${COMMIT_SHA}',
-        'axe',
-      ]
+  # - id: upload-axe-results-gcs
+  #   name: 'gcr.io/cloud-builders/gsutil@sha256:3cb717eb2b8e1e8140868a08d31af752f7ec99949f78023743df2fc6bd41512e'
+  #   entrypoint: 'bash'
+  #   args:
+  #     - '-c'
+  #     - |
+  #       gsutil cp /workspace/axe-results/ci_axe_results_*.json \
+  #       gs://safe-inputs-devsecops-outputs-for-dashboard/axe-ci-results/$BRANCH_NAME-$COMMIT_SHA.json
 
-  - id: upload-axe-results-gcs
-    name: 'gcr.io/cloud-builders/gsutil@sha256:3cb717eb2b8e1e8140868a08d31af752f7ec99949f78023743df2fc6bd41512e'
-    entrypoint: 'bash'
-    args:
-      - '-c'
-      - |
-        gsutil cp /workspace/axe-results/ci_axe_results_*.json \
-        gs://safe-inputs-devsecops-outputs-for-dashboard/axe-ci-results/$BRANCH_NAME-$COMMIT_SHA.json
+  # - id: docker-compose-down-dev-environment
+  #   name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'
+  #   entrypoint: 'bash'
+  #   args:
+  #     - '-c'
+  #     - |
+  #       docker compose -f ./docker-compose.dev.yaml down -v
 
-  - id: docker-compose-down-dev-environment
-    name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'
-    entrypoint: 'bash'
-    args:
-      - '-c'
-      - |
-        docker compose -f ./docker-compose.dev.yaml down -v
+  # - id: generate-image-name
+  #   name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'
+  #   entrypoint: 'bash'
+  #   dir: ui
+  #   args:
+  #     - '-c'
+  #     - |
+  #       echo "northamerica-northeast1-docker.pkg.dev/${PROJECT_ID}/phx-01j1tbke0ax-safeinputs/ui:$BRANCH_NAME-$COMMIT_SHA-$(date +%s)" > /workspace/imagename
 
-  - id: generate-image-name
-    name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'
-    entrypoint: 'bash'
-    dir: ui
-    args:
-      - '-c'
-      - |
-        echo "northamerica-northeast1-docker.pkg.dev/${PROJECT_ID}/phx-01j1tbke0ax-safeinputs/ui:$BRANCH_NAME-$COMMIT_SHA-$(date +%s)" > /workspace/imagename
+  # - id: build-if-main
+  #   name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'
+  #   entrypoint: 'bash'
+  #   dir: ui
+  #   args:
+  #     - '-c'
+  #     - |
+  #       if [[ "$BRANCH_NAME" == "main" ]]
+  #       then
+  #         image=$(cat /workspace/imagename)
+  #         docker build -t $image -f ./Dockerfile.prod .
+  #       else
+  #         exit 0
+  #       fi
 
-  - id: build-if-main
-    name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'
-    entrypoint: 'bash'
-    dir: ui
-    args:
-      - '-c'
-      - |
-        if [[ "$BRANCH_NAME" == "main" ]]
-        then
-          image=$(cat /workspace/imagename)
-          docker build -t $image -f ./Dockerfile.prod .
-        else
-          exit 0
-        fi
-
-  - id: push-if-main
-    name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'
-    entrypoint: 'bash'
-    args:
-      - '-c'
-      - |
-        if [[ "$BRANCH_NAME" == "main" ]]
-        then
-          image=$(cat /workspace/imagename)
-          docker push $image
-        else
-          exit 0
-        fi
+  # - id: push-if-main
+  #   name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'
+  #   entrypoint: 'bash'
+  #   args:
+  #     - '-c'
+  #     - |
+  #       if [[ "$BRANCH_NAME" == "main" ]]
+  #       then
+  #         image=$(cat /workspace/imagename)
+  #         docker push $image
+  #       else
+  #         exit 0
+  #       fi
 options:
   defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET

--- a/ui/cloudbuild.yaml
+++ b/ui/cloudbuild.yaml
@@ -19,19 +19,20 @@ steps:
       - '-c'
       - |
         echo "Make globally writable coverge dir, to be mounted as a volume on the test container"
-        mkdir --mode 777 ./ui/coverage
+        mkdir -p ./coverage
         npm test
         echo "Listing coverage directory contents:"
         ls -la ./coverage
 
   - id: 'Upload test coverage'
     name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:latest'
+    dir: ui
     entrypoint: bash
     args:
       - '-c'
       - |
         echo "Copying coverage report to GCP bucket..."
-        gsutil -m cp -r ./ui/coverage/* gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/ui/
+        gsutil -m cp -r ./coverage/* gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/ui/
 
   - id: 'Axe a11y testing setup'
     name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'

--- a/ui/cloudbuild.yaml
+++ b/ui/cloudbuild.yaml
@@ -14,8 +14,12 @@ steps:
   - id: Test
     name: 'node:lts-alpine3.19@sha256:40dc4b415c17b85bea9be05314b4a753f45a4e1716bb31c01182e6c53d51a654'
     dir: ui
-    entrypoint: npm
-    args: ['test']
+    entrypoint: sh
+    args:
+      - '-c'
+      - |
+        mkdir -p ./coverage
+        npm test
 
   - id: 'Upload test coverage'
     name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:latest'

--- a/ui/cloudbuild.yaml
+++ b/ui/cloudbuild.yaml
@@ -63,7 +63,7 @@ steps:
         jq '.' coverage/coverage-summary.json > coverage/coverage-pretty.json
 
         echo "Copying coverage report to GCS bucket..."
-        gsutil -m cp -r ./coverage/coverage-pretty.json gs://test-outputs-go-here/test-coverage/ui/${BRANCH_NAME}__${timestamp}__${SHORT_SHA}.json
+        gsutil -m cp -r ./coverage/coverage-pretty.json gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/ui/${BRANCH_NAME}__${timestamp}__${SHORT_SHA}.json
 
   - id: 'Axe a11y testing setup'
     name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'

--- a/ui/cloudbuild.yaml
+++ b/ui/cloudbuild.yaml
@@ -30,9 +30,6 @@ steps:
         # Generate a timestamp
         export timestamp=$(date +%s)
 
-        echo $BRANCH_NAME
-        echo $SHORT_SHA
-
         # Get the last commit's coverage report from GCS
         echo "Getting last commit's test coverage report..."
         last_commit_on_this_branch=$(gsutil ls gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/ui/ | grep "$BRANCH_NAME" | sort | tail -n 1)
@@ -67,8 +64,6 @@ steps:
 
         echo "Copying coverage report to GCS bucket..."
         gsutil -m cp -r ./coverage/coverage-pretty.json gs://safe-inputs-devsecops-outputs-for-dashboard/test-coverage/ui/${BRANCH_NAME}__${timestamp}__${SHORT_SHA}.json
-
-        echo ${BRANCH_NAME}__${timestamp}__${SHORT_SHA}.json
 
   - id: 'Axe a11y testing setup'
     name: 'gcr.io/cloud-builders/docker@sha256:8a9bff005803926fbc760f9528b708c259ac170b5e93082a9c2342a731945f66'

--- a/ui/cloudbuild.yaml
+++ b/ui/cloudbuild.yaml
@@ -21,6 +21,8 @@ steps:
         echo "Make globally writable coverge dir, to be mounted as a volume on the test container"
         mkdir --mode 777 ./ui/coverage
         npm test
+        echo "Listing coverage directory contents:"
+        ls -la ./coverage
 
   - id: 'Upload test coverage'
     name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:latest'

--- a/ui/jest.config.cjs
+++ b/ui/jest.config.cjs
@@ -15,7 +15,9 @@ module.exports = {
     'i18n/locales',
     'test_utils',
   ],
-  coverageDirectory: '<rootDir>/ui/coverage',
+  collectCoverage: true,
+  coverageDirectory: './coverage',
+  coverageReporters: ['json'],
   moduleNameMapper: {
     '\\.(css|less|scss|sass)$': '<rootDir>/src/test_utils/mocks/styleMock.js',
     '\\.svg$': '<rootDir>/src/test_utils/mocks/svgMock.js',

--- a/ui/jest.config.cjs
+++ b/ui/jest.config.cjs
@@ -16,7 +16,6 @@ module.exports = {
     'test_utils',
   ],
   coverageDirectory: '<rootDir>/ui/coverage',
-  coverageReporters: ['json', 'text'],
   moduleNameMapper: {
     '\\.(css|less|scss|sass)$': '<rootDir>/src/test_utils/mocks/styleMock.js',
     '\\.svg$': '<rootDir>/src/test_utils/mocks/svgMock.js',

--- a/ui/jest.config.cjs
+++ b/ui/jest.config.cjs
@@ -15,6 +15,7 @@ module.exports = {
     'i18n/locales',
     'test_utils',
   ],
+  coverageDirectory: '<rootDir>/ui/coverage',
   moduleNameMapper: {
     '\\.(css|less|scss|sass)$': '<rootDir>/src/test_utils/mocks/styleMock.js',
     '\\.svg$': '<rootDir>/src/test_utils/mocks/svgMock.js',

--- a/ui/jest.config.cjs
+++ b/ui/jest.config.cjs
@@ -15,9 +15,7 @@ module.exports = {
     'i18n/locales',
     'test_utils',
   ],
-  collectCoverage: true,
   coverageDirectory: './coverage',
-  coverageReporters: ['json'],
   moduleNameMapper: {
     '\\.(css|less|scss|sass)$': '<rootDir>/src/test_utils/mocks/styleMock.js',
     '\\.svg$': '<rootDir>/src/test_utils/mocks/svgMock.js',

--- a/ui/jest.config.cjs
+++ b/ui/jest.config.cjs
@@ -15,7 +15,6 @@ module.exports = {
     'i18n/locales',
     'test_utils',
   ],
-  coverageDirectory: './coverage',
   moduleNameMapper: {
     '\\.(css|less|scss|sass)$': '<rootDir>/src/test_utils/mocks/styleMock.js',
     '\\.svg$': '<rootDir>/src/test_utils/mocks/svgMock.js',

--- a/ui/jest.config.cjs
+++ b/ui/jest.config.cjs
@@ -16,6 +16,7 @@ module.exports = {
     'test_utils',
   ],
   coverageDirectory: '<rootDir>/ui/coverage',
+  coverageReporters: ['json', 'text'],
   moduleNameMapper: {
     '\\.(css|less|scss|sass)$': '<rootDir>/src/test_utils/mocks/styleMock.js',
     '\\.svg$': '<rootDir>/src/test_utils/mocks/svgMock.js',

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,7 +9,7 @@
     "precompile": "npm run extract",
     "compile": "lingui compile --typescript",
     "dev": "rspack serve",
-    "test": "jest --coverage --coverageReporters text --json --outputFile=coverage.json",
+    "test": "jest --coverage --coverageReporters text --json --outputFile=./coverage/coverage.json",
     "test:debug": "node --inspect='0.0.0.0:9229' node_modules/.bin/jest --runInBand --no-cache",
     "typecheck": "tsc --noEmit"
   },

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,7 +9,7 @@
     "precompile": "npm run extract",
     "compile": "lingui compile --typescript",
     "dev": "rspack serve",
-    "test": "jest --coverage --coverageReporters json,text",
+    "test": "jest --coverage --coverageReporters text",
     "test:debug": "node --inspect='0.0.0.0:9229' node_modules/.bin/jest --runInBand --no-cache",
     "typecheck": "tsc --noEmit"
   },

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,7 +9,7 @@
     "precompile": "npm run extract",
     "compile": "lingui compile --typescript",
     "dev": "rspack serve",
-    "test": "jest --coverage --coverageReporters text",
+    "test": "jest --coverage --coverageReporters text --json --outputFile=coverage.json",
     "test:debug": "node --inspect='0.0.0.0:9229' node_modules/.bin/jest --runInBand --no-cache",
     "typecheck": "tsc --noEmit"
   },

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,7 +9,7 @@
     "precompile": "npm run extract",
     "compile": "lingui compile --typescript",
     "dev": "rspack serve",
-    "test": "jest --coverage --coverageReporters json",
+    "test": "jest --coverage --coverageReporters json,text",
     "test:debug": "node --inspect='0.0.0.0:9229' node_modules/.bin/jest --runInBand --no-cache",
     "typecheck": "tsc --noEmit"
   },

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,7 +9,7 @@
     "precompile": "npm run extract",
     "compile": "lingui compile --typescript",
     "dev": "rspack serve",
-    "test": "jest --coverage --coverageReporters text",
+    "test": "jest --coverage --coverageReporters text --coverageDirectory ./coverage",
     "test:debug": "node --inspect='0.0.0.0:9229' node_modules/.bin/jest --runInBand --no-cache",
     "typecheck": "tsc --noEmit"
   },

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,7 +9,7 @@
     "precompile": "npm run extract",
     "compile": "lingui compile --typescript",
     "dev": "rspack serve",
-    "test": "jest --coverage --coverageReporters text --coverageDirectory ./coverage",
+    "test": "jest --coverage --coverageReporters json",
     "test:debug": "node --inspect='0.0.0.0:9229' node_modules/.bin/jest --runInBand --no-cache",
     "typecheck": "tsc --noEmit"
   },

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,7 +9,7 @@
     "precompile": "npm run extract",
     "compile": "lingui compile --typescript",
     "dev": "rspack serve",
-    "test": "jest --coverage --coverageReporters text --json --outputFile=./coverage/coverage.json",
+    "test": "jest --coverage --coverageReporters json --coverageDirectory ./coverage",
     "test:debug": "node --inspect='0.0.0.0:9229' node_modules/.bin/jest --runInBand --no-cache",
     "typecheck": "tsc --noEmit"
   },

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,7 +9,7 @@
     "precompile": "npm run extract",
     "compile": "lingui compile --typescript",
     "dev": "rspack serve",
-    "test": "jest --coverage --coverageReporters json --coverageDirectory ./coverage",
+    "test": "jest --coverage --coverageReporters=json-summary --coverageReporters=text --coverageDirectory ./coverage",
     "test:debug": "node --inspect='0.0.0.0:9229' node_modules/.bin/jest --runInBand --no-cache",
     "typecheck": "tsc --noEmit"
   },


### PR DESCRIPTION
Collects and saves test coverage reports with the _ui_, _api_ and _axe-testing_ cloudbuild.yamls. 
If there's a previous commit on the current branch, it extracts the previous commits code coverage percentage (statements) and appends the difference to the report file (to see if coverage is trending up or down). 

This doesn't yet involve README badges nor does it make use of a threshold to fail.  Just informational at the moment. 