### PR TITLE
feat: save commit sha to bucket when images are pushed 

### DIFF
--- a/api/cloudbuild.yaml
+++ b/api/cloudbuild.yaml
@@ -85,5 +85,19 @@ steps:
         else
           exit 0
         fi
+
+  - id: save-current-commit-sha-to-gcs-bucket
+    # This is a workaround to be used to filter vulnerabilities for dashboard
+    name: 'gcr.io/cloud-builders/gsutil@sha256:386bf19745cfa9976fc9e7f979857090be9152b30bf3f50527c6ace1de9d2673'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        if [[ "$BRANCH_NAME" = "main" ]]; then
+          # Pipe the commit SHA directly to gsutil cp, which will create the file in the bucket.
+          echo "$COMMIT_SHA" | gsutil cp - gs://safe-inputs-devsecops-outputs-for-dashboard/COMMIT_SHAs/api__$COMMIT_SHA.txt
+        else
+          exit 0
+        fi
 options:
   defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET

--- a/devsecops/artifact-registry-vulnerability-scanning/cloudbuild.yaml
+++ b/devsecops/artifact-registry-vulnerability-scanning/cloudbuild.yaml
@@ -1,25 +1,40 @@
 steps:
   - id: deploy-cloud-function-if-main
     name: 'gcr.io/google.com/cloudsdktool/cloud-sdk@sha256:3a24ff5f089d9ce3627306873ef1e1061488a63ae12c0bd0b5c24ec5ee594798'
-    dir: devsecops/artifact-registry-vulnerability-scanning/
+    dir: devsecops/artifact-registry-vulnerability-scanning
     entrypoint: 'bash'
     args:
       - '-c'
       - |
-        gcloud functions deploy imageVulnPubSubHandler \
-          --gen2 \
-          --source=./cloud-function \
-          --runtime=nodejs18 \
-          --trigger-topic=container-analysis-occurrences-v1 \
-          --entry-point=imageVulnPubSubHandler \
-          --set-env-vars=BUCKET_NAME=${_BUCKET_NAME} \
-          --region=northamerica-northeast1 \
-          --build-service-account=projects/phx-01j1tbke0ax/serviceAccounts/phx-01j1tbke0ax-cloudbuild@phx-01j1tbke0ax.iam.gserviceaccount.com \
-          --service-account=phx-01j1tbke0ax-vuln-gcf@phx-01j1tbke0ax.iam.gserviceaccount.com \
-          --docker-repository=northamerica-northeast1-docker.pkg.dev/phx-01j1tbke0ax/phx-01j1tbke0ax-vuln-cloudfunction
+        if [[ "$BRANCH_NAME" = "main" ]]; then
+          gcloud functions deploy imageVulnPubSubHandler \
+            --gen2 \
+            --source=./cloud-function \
+            --runtime=nodejs18 \
+            --trigger-topic=container-analysis-occurrences-v1 \
+            --entry-point=imageVulnPubSubHandler \
+            --set-env-vars=BUCKET_NAME=${_BUCKET_NAME} \
+            --region=northamerica-northeast1 \
+            --build-service-account=projects/phx-01j1tbke0ax/serviceAccounts/phx-01j1tbke0ax-cloudbuild@phx-01j1tbke0ax.iam.gserviceaccount.com \
+            --service-account=phx-01j1tbke0ax-vuln-gcf@phx-01j1tbke0ax.iam.gserviceaccount.com \
+            --docker-repository=northamerica-northeast1-docker.pkg.dev/phx-01j1tbke0ax/phx-01j1tbke0ax-vuln-cloudfunction
+        else
+          exit 0
+        fi
 
-substitutions:
-  _BUCKET_NAME: safe-inputs-devsecops-outputs-for-dashboard
+  - id: save-current-commit-sha-to-gcs-bucket
+    # This is a workaround to be used to filter vulnerabilities for dashboard
+    name: 'gcr.io/cloud-builders/gsutil@sha256:386bf19745cfa9976fc9e7f979857090be9152b30bf3f50527c6ace1de9d2673'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        if [[ "$BRANCH_NAME" = "main" ]]; then
+          # Pipe the commit SHA directly to gsutil cp, which will create the file in the bucket.
+          echo "$COMMIT_SHA" | gsutil cp - gs://safe-inputs-devsecops-outputs-for-dashboard/COMMIT_SHAs/vuln-gcf__$COMMIT_SHA.txt
+        else
+          exit 0
+        fi
 
 options:
   defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET

--- a/ui/cloudbuild.yaml
+++ b/ui/cloudbuild.yaml
@@ -135,5 +135,20 @@ steps:
         else
           exit 0
         fi
+
+  - id: save-current-commit-sha-to-gcs-bucket
+    # This is a workaround to be used to filter vulnerabilities for dashboard
+    name: 'gcr.io/cloud-builders/gsutil@sha256:386bf19745cfa9976fc9e7f979857090be9152b30bf3f50527c6ace1de9d2673'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        if [[ "$BRANCH_NAME" = "main" ]]; then
+          # Pipe the commit SHA directly to gsutil cp, which will create the file in the bucket.
+          echo "$COMMIT_SHA" | gsutil cp - gs://safe-inputs-devsecops-outputs-for-dashboard/COMMIT_SHAs/ui__$COMMIT_SHA.txt
+        else
+          exit 0
+        fi
+
 options:
   defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET


### PR DESCRIPTION
This is a workaround in order to easily (for now) filter current image vulnerabilities in the dashboard. 

Added as a final step in the ui, api, and cloud function cloudbuild.yamls.  Also re-added the if main conditional around the function that was removed when troubleshooting service accounts. 