### PR TITLE
fix: change to using the Artifact Registry digest as opposed to the git commit SHA

### DIFF
--- a/api/cloudbuild.yaml
+++ b/api/cloudbuild.yaml
@@ -86,16 +86,24 @@ steps:
           exit 0
         fi
 
-  - id: save-current-commit-sha-to-gcs-bucket
-    # This is a workaround to be used to filter vulnerabilities for dashboard
-    name: 'gcr.io/cloud-builders/gsutil@sha256:386bf19745cfa9976fc9e7f979857090be9152b30bf3f50527c6ace1de9d2673'
+  - id: get-and-save-artifact-registry-image-digest-if-main
+    # This is a workaround to help filter only current image vulnerabilities for dashboard - we need the AR image digest for this.  
+    name: 'gcr.io/cloud-builders/docker@sha256:b991d50960b337f581ad77ea2a59259a786d177019aa64d8b3acb01f65dbc154'
     entrypoint: 'bash'
     args:
       - '-c'
       - |
-        if [[ "$BRANCH_NAME" = "main" ]]; then
-          # Pipe the commit SHA directly to gsutil cp, which will create the file in the bucket.
-          echo "$COMMIT_SHA" | gsutil cp - gs://safe-inputs-devsecops-outputs-for-dashboard/COMMIT_SHAs/api__$COMMIT_SHA.txt
+        if [[ "$BRANCH_NAME" == "main" ]]
+        then
+        short_digest=$(gcloud artifacts files list \
+          --project=phx-01j1tbke0ax \
+          --repository=phx-01j1tbke0ax-safeinputs \
+          --location=northamerica-northeast1 \
+          --package=api \
+          --tag=$BRANCH_NAME-$SHORT_SHA-$(date +%s) \
+          --format="value(name)" | awk -F'sha256:' '{print substr($2, 1, 12)}')
+        
+          echo "$short_digest" | gsutil cp - gs://safe-inputs-devsecops-outputs-for-dashboard/COMMIT_SHAs/api__$short_digest.txt
         else
           exit 0
         fi

--- a/devsecops/artifact-registry-vulnerability-scanning/cloudbuild.yaml
+++ b/devsecops/artifact-registry-vulnerability-scanning/cloudbuild.yaml
@@ -1,4 +1,5 @@
 steps:
+
   - id: deploy-cloud-function-if-main
     name: 'gcr.io/google.com/cloudsdktool/cloud-sdk@sha256:3a24ff5f089d9ce3627306873ef1e1061488a63ae12c0bd0b5c24ec5ee594798'
     dir: devsecops/artifact-registry-vulnerability-scanning
@@ -22,19 +23,31 @@ steps:
           exit 0
         fi
 
-  - id: save-current-commit-sha-to-gcs-bucket
-    # This is a workaround to be used to filter vulnerabilities for dashboard
-    name: 'gcr.io/cloud-builders/gsutil@sha256:386bf19745cfa9976fc9e7f979857090be9152b30bf3f50527c6ace1de9d2673'
+  - id: get-and-save-artifact-registry-image-digest-if-main
+    # This is a workaround to help filter only current image vulnerabilities for dashboard - we need the AR image digest for this.
+    # No tags, unfortunately with this one, it's autocreated with the deployment, so first sorting to get most recent. 
+    name: 'gcr.io/cloud-builders/docker@sha256:b991d50960b337f581ad77ea2a59259a786d177019aa64d8b3acb01f65dbc154'
     entrypoint: 'bash'
     args:
       - '-c'
       - |
-        if [[ "$BRANCH_NAME" = "main" ]]; then
-          # Pipe the commit SHA directly to gsutil cp, which will create the file in the bucket.
-          echo "$COMMIT_SHA" | gsutil cp - gs://safe-inputs-devsecops-outputs-for-dashboard/COMMIT_SHAs/vuln-gcf__$COMMIT_SHA.txt
+        if [[ "$BRANCH_NAME" == "main" ]]
+        then
+        short_digest=$(gcloud artifacts files list \
+          --project=phx-01j1tbke0ax \
+          --repository=phx-01j1tbke0ax-vuln-cloudfunction \
+          --location=northamerica-northeast1 \
+          --package=phx--01j1tbke0ax__northamerica--northeast1__image_vuln_pub_sub_handler \
+          --sort-by=~CREATE_TIME \
+          --limit=1 \
+          --format="value(name)" | awk -F'sha256:' '{print substr($2, 1, 12)}')
+        
+          echo "$short_digest" | gsutil cp - gs://safe-inputs-devsecops-outputs-for-dashboard/COMMIT_SHAs/gcf-vuln__$short_digest.txt
         else
           exit 0
         fi
 
 options:
   defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET
+
+

--- a/ui/cloudbuild.yaml
+++ b/ui/cloudbuild.yaml
@@ -136,16 +136,24 @@ steps:
           exit 0
         fi
 
-  - id: save-current-commit-sha-to-gcs-bucket
-    # This is a workaround to be used to filter vulnerabilities for dashboard
-    name: 'gcr.io/cloud-builders/gsutil@sha256:386bf19745cfa9976fc9e7f979857090be9152b30bf3f50527c6ace1de9d2673'
+  - id: get-and-save-artifact-registry-image-digest-if-main
+    # This is a workaround to help filter only current image vulnerabilities for dashboard - we need the AR image digest for this.  
+    name: 'gcr.io/cloud-builders/docker@sha256:b991d50960b337f581ad77ea2a59259a786d177019aa64d8b3acb01f65dbc154'
     entrypoint: 'bash'
     args:
       - '-c'
       - |
-        if [[ "$BRANCH_NAME" = "main" ]]; then
-          # Pipe the commit SHA directly to gsutil cp, which will create the file in the bucket.
-          echo "$COMMIT_SHA" | gsutil cp - gs://safe-inputs-devsecops-outputs-for-dashboard/COMMIT_SHAs/ui__$COMMIT_SHA.txt
+        if [[ "$BRANCH_NAME" == "main" ]]
+        then
+        short_digest=$(gcloud artifacts files list \
+          --project=phx-01j1tbke0ax \
+          --repository=phx-01j1tbke0ax-safeinputs \
+          --location=northamerica-northeast1 \
+          --package=ui \
+          --tag=$BRANCH_NAME-$SHORT_SHA-$(date +%s) \
+          --format="value(name)" | awk -F'sha256:' '{print substr($2, 1, 12)}')
+        
+          echo "$short_digest" | gsutil cp - gs://safe-inputs-devsecops-outputs-for-dashboard/COMMIT_SHAs/ui__$short_digest.txt
         else
           exit 0
         fi


### PR DESCRIPTION
Was working to filter the vulnerabilities on the dashboard to only include ones attached to current images. None were showing up, so then realized that its not the tag that's being used on the vulnerabilities, but the digest SHA.  So changed the cloudbuilds to (get and) save this instead. Also swapped to using the short sha. 