### PR TITLE
fix: changed base image of the get-and-save-artifact-registry-image-digest-if-main cloudbuild steps 

### DIFF
--- a/api/cloudbuild.yaml
+++ b/api/cloudbuild.yaml
@@ -88,7 +88,7 @@ steps:
 
   - id: get-and-save-artifact-registry-image-digest-if-main
     # This is a workaround to help filter only current image vulnerabilities for dashboard - we need the AR image digest for this.
-    name: 'gcr.io/cloud-builders/docker@sha256:b991d50960b337f581ad77ea2a59259a786d177019aa64d8b3acb01f65dbc154'
+    name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:latest@sha256:3a24ff5f089d9ce3627306873ef1e1061488a63ae12c0bd0b5c24ec5ee594798'
     entrypoint: 'bash'
     args:
       - '-c'

--- a/api/cloudbuild.yaml
+++ b/api/cloudbuild.yaml
@@ -93,17 +93,17 @@ steps:
     args:
       - '-c'
       - |
-        if [[ "$BRANCH_NAME" == "main" ]]
+        if [[ "${BRANCH_NAME}" == "main" ]]
         then
         short_digest=$(gcloud artifacts files list \
           --project=phx-01j1tbke0ax \
           --repository=phx-01j1tbke0ax-safeinputs \
           --location=northamerica-northeast1 \
           --package=api \
-          --tag=$BRANCH_NAME-$SHORT_SHA-$(date +%s) \
+          --tag="${BRANCH_NAME}-${SHORT_SHA}-$(date +%s)" \
           --format="value(name)" | awk -F'sha256:' '{print substr($2, 1, 12)}')
 
-          echo "$short_digest" | gsutil cp - gs://safe-inputs-devsecops-outputs-for-dashboard/COMMIT_SHAs/api__$short_digest.txt
+          echo "${short_digest}" | gsutil cp - "gs://safe-inputs-devsecops-outputs-for-dashboard/COMMIT_SHAs/api__${short_digest}.txt"
         else
           exit 0
         fi

--- a/api/cloudbuild.yaml
+++ b/api/cloudbuild.yaml
@@ -86,16 +86,24 @@ steps:
           exit 0
         fi
 
-  - id: save-current-commit-sha-to-gcs-bucket
-    # This is a workaround to be used to filter vulnerabilities for dashboard
-    name: 'gcr.io/cloud-builders/gsutil@sha256:386bf19745cfa9976fc9e7f979857090be9152b30bf3f50527c6ace1de9d2673'
+  - id: get-and-save-artifact-registry-image-digest-if-main
+    # This is a workaround to help filter only current image vulnerabilities for dashboard - we need the AR image digest for this.  
+    name: 'gcr.io/cloud-builders/docker@sha256:b991d50960b337f581ad77ea2a59259a786d177019aa64d8b3acb01f65dbc154'
     entrypoint: 'bash'
     args:
       - '-c'
       - |
-        if [[ "$BRANCH_NAME" = "main" ]]; then
-          # Pipe the commit SHA directly to gsutil cp, which will create the file in the bucket.
-          echo "$COMMIT_SHA" | gsutil cp - gs://safe-inputs-devsecops-outputs-for-dashboard/COMMIT_SHAs/api__$COMMIT_SHA.txt
+        if [[ "$BRANCH_NAME" == "main" ]]
+        then
+        short_digest=$(gcloud artifacts files list \
+          --project=phx-01j1tbke0ax \
+          --repository=phx-01j1tbke0ax-safeinputs \
+          --location=northamerica-northeast1 \
+          --package=api \
+          --tag=$BRANCH_NAME-$SHORT_SHA-$(date +%s) \
+          --format="value(name)" | awk -F'sha256:' '{print substr($2, 1, 12)}')
+        
+          echo "$short_digest" | gsutil cp - gs://safe-inputs-devsecops-outputs-for-dashboard/COMMIT_SHAs/api__$short_digest.txt
         else
           exit 0
         fi

--- a/api/cloudbuild.yaml
+++ b/api/cloudbuild.yaml
@@ -87,7 +87,7 @@ steps:
         fi
 
   - id: get-and-save-artifact-registry-image-digest-if-main
-    # This is a workaround to help filter only current image vulnerabilities for dashboard - we need the AR image digest for this.  
+    # This is a workaround to help filter only current image vulnerabilities for dashboard - we need the AR image digest for this.
     name: 'gcr.io/cloud-builders/docker@sha256:b991d50960b337f581ad77ea2a59259a786d177019aa64d8b3acb01f65dbc154'
     entrypoint: 'bash'
     args:
@@ -102,7 +102,7 @@ steps:
           --package=api \
           --tag=$BRANCH_NAME-$SHORT_SHA-$(date +%s) \
           --format="value(name)" | awk -F'sha256:' '{print substr($2, 1, 12)}')
-        
+
           echo "$short_digest" | gsutil cp - gs://safe-inputs-devsecops-outputs-for-dashboard/COMMIT_SHAs/api__$short_digest.txt
         else
           exit 0

--- a/devsecops/artifact-registry-vulnerability-scanning/cloudbuild.yaml
+++ b/devsecops/artifact-registry-vulnerability-scanning/cloudbuild.yaml
@@ -32,15 +32,18 @@ steps:
       - |
         if [[ "${BRANCH_NAME}" == "main" ]]
         then
-        short_digest="$(gcloud artifacts files list \
-          --project=phx-01j1tbke0ax \
-          --repository=phx-01j1tbke0ax-vuln-cloudfunction \
-          --location=northamerica-northeast1 \
-          --package=phx--01j1tbke0ax__northamerica--northeast1__image_vuln_pub_sub_handler \
-          --sort-by=~CREATE_TIME)"
+          short_digest="$(gcloud artifacts files list \
+            --project=phx-01j1tbke0ax \
+            --repository=phx-01j1tbke0ax-vuln-cloudfunction \
+            --location=northamerica-northeast1 \
+            --package=phx--01j1tbke0ax__northamerica--northeast1__image_vuln_pub_sub_handler \
+            --sort-by=~CREATE_TIME)"
 
-        short_sha="$(echo "${short_digest}" | awk -F'sha256:' 'NR==1 {print substr($2, 1, 12)}')"
-        echo "${short_sha}" | gsutil cp - "gs://safe-inputs-devsecops-outputs-for-dashboard/COMMIT_SHAs/gcf-vuln__${short_sha}.txt"
+          short_sha="$(echo "${short_digest}" | awk -F'sha256:' 'NR==1 {print substr($2, 1, 12)}')"
+          echo "${short_sha}" | gsutil cp - "gs://safe-inputs-devsecops-outputs-for-dashboard/COMMIT_SHAs/gcf-vuln__${short_sha}.txt"
+        else
+          exit 0
+        fi
 
 options:
   defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET

--- a/devsecops/artifact-registry-vulnerability-scanning/cloudbuild.yaml
+++ b/devsecops/artifact-registry-vulnerability-scanning/cloudbuild.yaml
@@ -30,21 +30,17 @@ steps:
     args:
       - '-c'
       - |
-        if [[ "$BRANCH_NAME" == "main" ]]
+        if [[ "${BRANCH_NAME}" == "main" ]]
         then
-        short_digest=$(gcloud artifacts files list \
+        short_digest="$(gcloud artifacts files list \
           --project=phx-01j1tbke0ax \
           --repository=phx-01j1tbke0ax-vuln-cloudfunction \
           --location=northamerica-northeast1 \
           --package=phx--01j1tbke0ax__northamerica--northeast1__image_vuln_pub_sub_handler \
-          --sort-by=~CREATE_TIME \
-          --limit=1 \
-          --format="value(name)" | awk -F'sha256:' '{print substr($2, 1, 12)}')
+          --sort-by=~CREATE_TIME)"
 
-          echo "$short_digest" | gsutil cp - gs://safe-inputs-devsecops-outputs-for-dashboard/COMMIT_SHAs/gcf-vuln__$short_digest.txt
-        else
-          exit 0
-        fi
+        short_sha="$(echo "${short_digest}" | awk -F'sha256:' 'NR==1 {print substr($2, 1, 12)}')"
+        echo "${short_sha}" | gsutil cp - "gs://safe-inputs-devsecops-outputs-for-dashboard/COMMIT_SHAs/gcf-vuln__${short_sha}.txt"
 
 options:
   defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET

--- a/devsecops/artifact-registry-vulnerability-scanning/cloudbuild.yaml
+++ b/devsecops/artifact-registry-vulnerability-scanning/cloudbuild.yaml
@@ -1,4 +1,5 @@
 steps:
+
   - id: deploy-cloud-function-if-main
     name: 'gcr.io/google.com/cloudsdktool/cloud-sdk@sha256:3a24ff5f089d9ce3627306873ef1e1061488a63ae12c0bd0b5c24ec5ee594798'
     dir: devsecops/artifact-registry-vulnerability-scanning
@@ -22,19 +23,31 @@ steps:
           exit 0
         fi
 
-  - id: save-current-commit-sha-to-gcs-bucket
-    # This is a workaround to be used to filter vulnerabilities for dashboard
-    name: 'gcr.io/cloud-builders/gsutil@sha256:386bf19745cfa9976fc9e7f979857090be9152b30bf3f50527c6ace1de9d2673'
+  - id: get-and-save-artifact-registry-image-digest-if-main
+    # This is a workaround to help filter only current image vulnerabilities for dashboard - we need the AR image digest for this.
+    # No tags, unfortunately with this one, it's autocreated with the deployment, so first sorting to get most recent. 
+    name: 'gcr.io/cloud-builders/docker@sha256:b991d50960b337f581ad77ea2a59259a786d177019aa64d8b3acb01f65dbc154'
     entrypoint: 'bash'
     args:
       - '-c'
       - |
-        if [[ "$BRANCH_NAME" = "main" ]]; then
-          # Pipe the commit SHA directly to gsutil cp, which will create the file in the bucket.
-          echo "$COMMIT_SHA" | gsutil cp - gs://safe-inputs-devsecops-outputs-for-dashboard/COMMIT_SHAs/vuln-gcf__$COMMIT_SHA.txt
+        if [[ "$BRANCH_NAME" == "main" ]]
+        then
+        short_digest=$(gcloud artifacts files list \
+          --project=phx-01j1tbke0ax \
+          --repository=phx-01j1tbke0ax-vuln-cloudfunction \
+          --location=northamerica-northeast1 \
+          --package=phx--01j1tbke0ax__northamerica--northeast1__image_vuln_pub_sub_handler \
+          --sort-by=~CREATE_TIME \
+          --limit=1 \
+          --format="value(name)" | awk -F'sha256:' '{print substr($2, 1, 12)}')
+        
+          echo "$short_digest" | gsutil cp - gs://safe-inputs-devsecops-outputs-for-dashboard/COMMIT_SHAs/gcf-vuln__$short_digest.txt
         else
           exit 0
         fi
 
 options:
   defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET
+
+

--- a/devsecops/artifact-registry-vulnerability-scanning/cloudbuild.yaml
+++ b/devsecops/artifact-registry-vulnerability-scanning/cloudbuild.yaml
@@ -1,5 +1,4 @@
 steps:
-
   - id: deploy-cloud-function-if-main
     name: 'gcr.io/google.com/cloudsdktool/cloud-sdk@sha256:3a24ff5f089d9ce3627306873ef1e1061488a63ae12c0bd0b5c24ec5ee594798'
     dir: devsecops/artifact-registry-vulnerability-scanning
@@ -25,7 +24,7 @@ steps:
 
   - id: get-and-save-artifact-registry-image-digest-if-main
     # This is a workaround to help filter only current image vulnerabilities for dashboard - we need the AR image digest for this.
-    # No tags, unfortunately with this one, it's autocreated with the deployment, so first sorting to get most recent. 
+    # No tags, unfortunately with this one, it's autocreated with the deployment, so first sorting to get most recent.
     name: 'gcr.io/cloud-builders/docker@sha256:b991d50960b337f581ad77ea2a59259a786d177019aa64d8b3acb01f65dbc154'
     entrypoint: 'bash'
     args:
@@ -41,7 +40,7 @@ steps:
           --sort-by=~CREATE_TIME \
           --limit=1 \
           --format="value(name)" | awk -F'sha256:' '{print substr($2, 1, 12)}')
-        
+
           echo "$short_digest" | gsutil cp - gs://safe-inputs-devsecops-outputs-for-dashboard/COMMIT_SHAs/gcf-vuln__$short_digest.txt
         else
           exit 0
@@ -49,5 +48,3 @@ steps:
 
 options:
   defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET
-
-

--- a/devsecops/artifact-registry-vulnerability-scanning/cloudbuild.yaml
+++ b/devsecops/artifact-registry-vulnerability-scanning/cloudbuild.yaml
@@ -25,7 +25,7 @@ steps:
   - id: get-and-save-artifact-registry-image-digest-if-main
     # This is a workaround to help filter only current image vulnerabilities for dashboard - we need the AR image digest for this.
     # No tags, unfortunately with this one, it's autocreated with the deployment, so first sorting to get most recent.
-    name: 'gcr.io/cloud-builders/docker@sha256:b991d50960b337f581ad77ea2a59259a786d177019aa64d8b3acb01f65dbc154'
+    name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:latest@sha256:3a24ff5f089d9ce3627306873ef1e1061488a63ae12c0bd0b5c24ec5ee594798'
     entrypoint: 'bash'
     args:
       - '-c'

--- a/devsecops/artifact-registry-vulnerability-scanning/cloudbuild.yaml
+++ b/devsecops/artifact-registry-vulnerability-scanning/cloudbuild.yaml
@@ -32,15 +32,15 @@ steps:
       - |
         if [[ "${BRANCH_NAME}" == "main" ]]
         then
-          short_digest="$(gcloud artifacts files list \
+          artifact_registry_digests="$(gcloud artifacts files list \
             --project=phx-01j1tbke0ax \
             --repository=phx-01j1tbke0ax-vuln-cloudfunction \
             --location=northamerica-northeast1 \
             --package=phx--01j1tbke0ax__northamerica--northeast1__image_vuln_pub_sub_handler \
             --sort-by=~CREATE_TIME)"
 
-          short_sha="$(echo "${short_digest}" | awk -F'sha256:' 'NR==1 {print substr($2, 1, 12)}')"
-          echo "${short_sha}" | gsutil cp - "gs://safe-inputs-devsecops-outputs-for-dashboard/COMMIT_SHAs/gcf-vuln__${short_sha}.txt"
+          most_recent_sha="$(echo "${artifact_registry_digests}" | awk -F'sha256:' 'NR==1 {print substr($2, 1, 12)}')"
+          echo "${most_recent_sha}" | gsutil cp - "gs://safe-inputs-devsecops-outputs-for-dashboard/COMMIT_SHAs/gcf-vuln__${most_recent_sha}.txt"
         else
           exit 0
         fi

--- a/ui/cloudbuild.yaml
+++ b/ui/cloudbuild.yaml
@@ -136,16 +136,24 @@ steps:
           exit 0
         fi
 
-  - id: save-current-commit-sha-to-gcs-bucket
-    # This is a workaround to be used to filter vulnerabilities for dashboard
-    name: 'gcr.io/cloud-builders/gsutil@sha256:386bf19745cfa9976fc9e7f979857090be9152b30bf3f50527c6ace1de9d2673'
+  - id: get-and-save-artifact-registry-image-digest-if-main
+    # This is a workaround to help filter only current image vulnerabilities for dashboard - we need the AR image digest for this.  
+    name: 'gcr.io/cloud-builders/docker@sha256:b991d50960b337f581ad77ea2a59259a786d177019aa64d8b3acb01f65dbc154'
     entrypoint: 'bash'
     args:
       - '-c'
       - |
-        if [[ "$BRANCH_NAME" = "main" ]]; then
-          # Pipe the commit SHA directly to gsutil cp, which will create the file in the bucket.
-          echo "$COMMIT_SHA" | gsutil cp - gs://safe-inputs-devsecops-outputs-for-dashboard/COMMIT_SHAs/ui__$COMMIT_SHA.txt
+        if [[ "$BRANCH_NAME" == "main" ]]
+        then
+        short_digest=$(gcloud artifacts files list \
+          --project=phx-01j1tbke0ax \
+          --repository=phx-01j1tbke0ax-safeinputs \
+          --location=northamerica-northeast1 \
+          --package=ui \
+          --tag=$BRANCH_NAME-$SHORT_SHA-$(date +%s) \
+          --format="value(name)" | awk -F'sha256:' '{print substr($2, 1, 12)}')
+        
+          echo "$short_digest" | gsutil cp - gs://safe-inputs-devsecops-outputs-for-dashboard/COMMIT_SHAs/ui__$short_digest.txt
         else
           exit 0
         fi

--- a/ui/cloudbuild.yaml
+++ b/ui/cloudbuild.yaml
@@ -137,7 +137,7 @@ steps:
         fi
 
   - id: get-and-save-artifact-registry-image-digest-if-main
-    # This is a workaround to help filter only current image vulnerabilities for dashboard - we need the AR image digest for this.  
+    # This is a workaround to help filter only current image vulnerabilities for dashboard - we need the AR image digest for this.
     name: 'gcr.io/cloud-builders/docker@sha256:b991d50960b337f581ad77ea2a59259a786d177019aa64d8b3acb01f65dbc154'
     entrypoint: 'bash'
     args:
@@ -152,7 +152,7 @@ steps:
           --package=ui \
           --tag=$BRANCH_NAME-$SHORT_SHA-$(date +%s) \
           --format="value(name)" | awk -F'sha256:' '{print substr($2, 1, 12)}')
-        
+
           echo "$short_digest" | gsutil cp - gs://safe-inputs-devsecops-outputs-for-dashboard/COMMIT_SHAs/ui__$short_digest.txt
         else
           exit 0

--- a/ui/cloudbuild.yaml
+++ b/ui/cloudbuild.yaml
@@ -143,17 +143,17 @@ steps:
     args:
       - '-c'
       - |
-        if [[ "$BRANCH_NAME" == "main" ]]
+        if [[ "${BRANCH_NAME}" == "main" ]]
         then
-        short_digest=$(gcloud artifacts files list \
+        short_digest="$(gcloud artifacts files list \
           --project=phx-01j1tbke0ax \
           --repository=phx-01j1tbke0ax-safeinputs \
           --location=northamerica-northeast1 \
           --package=ui \
-          --tag=$BRANCH_NAME-$SHORT_SHA-$(date +%s) \
-          --format="value(name)" | awk -F'sha256:' '{print substr($2, 1, 12)}')
+          --tag="${BRANCH_NAME}-${SHORT_SHA}-$(date +%s)" \
+          --format="value(name)" | awk -F'sha256:' '{print substr($2, 1, 12)}')"
 
-          echo "$short_digest" | gsutil cp - gs://safe-inputs-devsecops-outputs-for-dashboard/COMMIT_SHAs/ui__$short_digest.txt
+          echo "${short_digest}" | gsutil cp - "gs://safe-inputs-devsecops-outputs-for-dashboard/COMMIT_SHAs/ui__${short_digest}.txt"
         else
           exit 0
         fi

--- a/ui/cloudbuild.yaml
+++ b/ui/cloudbuild.yaml
@@ -138,7 +138,7 @@ steps:
 
   - id: get-and-save-artifact-registry-image-digest-if-main
     # This is a workaround to help filter only current image vulnerabilities for dashboard - we need the AR image digest for this.
-    name: 'gcr.io/cloud-builders/docker@sha256:b991d50960b337f581ad77ea2a59259a786d177019aa64d8b3acb01f65dbc154'
+    name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:latest@sha256:3a24ff5f089d9ce3627306873ef1e1061488a63ae12c0bd0b5c24ec5ee594798'
     entrypoint: 'bash'
     args:
       - '-c'


### PR DESCRIPTION
gsuitl wasn't found in the base image for cloudbuild (https://console.cloud.google.com/cloud-build/builds;region=northamerica-northeast1/2c3143c4-9345-4dd1-bab8-57ca4bfb227a?invt=Abo8dw&project=phx-01j1tbke0ax), so swapped it for the cloud-sdk image.  This is a continuation/ fix of https://github.com/HC-IPPM/safe-inputs/pull/1131 (as the cloudbuilds for that PR failed on main branch). 